### PR TITLE
🐛： 修复等待超时后，仍然有任务在执行，但设备会被释放的bug

### DIFF
--- a/src/main/java/com/sonic/agent/tests/android/AndroidTestTaskBootThread.java
+++ b/src/main/java/com/sonic/agent/tests/android/AndroidTestTaskBootThread.java
@@ -144,6 +144,9 @@ public class AndroidTestTaskBootThread extends Thread {
 
     @Override
     public void run() {
+
+        boolean startTestSuccess = false;
+
         try {
             int wait = 0;
             while (!AndroidDeviceLocalStatus.startTest(udId)) {
@@ -161,6 +164,7 @@ public class AndroidTestTaskBootThread extends Thread {
             //启动测试
             try {
                 androidStepHandler.startAndroidDriver(udId);
+                startTestSuccess = true;
             } catch (Exception e) {
                 log.error(e.getMessage());
                 androidStepHandler.closeAndroidDriver();
@@ -194,9 +198,11 @@ public class AndroidTestTaskBootThread extends Thread {
             log.error("任务异常，中断：{}", e.getMessage());
             androidStepHandler.setResultDetailStatus(ResultDetailStatus.FAIL);
         } finally {
-            AndroidDeviceLocalStatus.finish(udId);
-            androidStepHandler.closeAndroidDriver();
-            androidStepHandler.sendStatus();
+            if (startTestSuccess) {
+                AndroidDeviceLocalStatus.finish(udId);
+                androidStepHandler.closeAndroidDriver();
+                androidStepHandler.sendStatus();
+            }
         }
     }
 }

--- a/src/main/java/com/sonic/agent/tests/android/AndroidTestTaskBootThread.java
+++ b/src/main/java/com/sonic/agent/tests/android/AndroidTestTaskBootThread.java
@@ -201,8 +201,8 @@ public class AndroidTestTaskBootThread extends Thread {
             if (startTestSuccess) {
                 AndroidDeviceLocalStatus.finish(udId);
                 androidStepHandler.closeAndroidDriver();
-                androidStepHandler.sendStatus();
             }
+            androidStepHandler.sendStatus();
         }
     }
 }


### PR DESCRIPTION
之前没注意，产生的一个bug。  
假如一个测试套件中，有三个case，这三个case都用同一台设备跑，且每一条的case都超过最长等待时间（现在是1小时）。  

那么现在case1跑了超过1小时了，case2，case3超时，进入下面的if逻辑，发送消息并return：  
```java
                if (wait >= 6 * 10) {
                    androidStepHandler.waitDeviceTimeOut();
                    androidStepHandler.sendStatus();
                    return;
                } else {
                    Thread.sleep(10000);
                }
```
但是以为上面的代码更外层有`try...catch...finally`，所以即便是`return`，也依然会执行`finally`的逻辑，而`finally`中的`AndroidDeviceLocalStatus.finish(udId)`会释放设备。如果这之后case1还在运行，同时进来case4，也是用同一台设备，那么case4执行`AndroidDeviceLocalStatus.startTest(udId)`将会返回true，造成设备重复占用。