### PR TITLE
🐛: 更改debug下的中断策略

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
@@ -3,6 +3,7 @@ package org.cloud.sonic.agent.tests;
 import org.cloud.sonic.agent.interfaces.PlatformType;
 import org.cloud.sonic.agent.tests.android.AndroidRunStepThread;
 import org.cloud.sonic.agent.tests.android.AndroidTestTaskBootThread;
+import org.cloud.sonic.agent.tests.common.RunStepThread;
 import org.cloud.sonic.agent.tests.ios.IOSTestTaskBootThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,7 +199,9 @@ public class TaskManager {
     }
 
     /**
-     * 强制停止子线程
+     * 停止子线程
+     * 不能使用 {@link Thread#stop()} 、{@link Thread#interrupt()} ，
+     * 因为目前的websocket会用当前所属线程做一些事，强制停止会导致一些问题
      *
      * @param key  子线程key
      */
@@ -208,8 +211,8 @@ public class TaskManager {
             return;
         }
         for (Thread thread : threads) {
-            AndroidRunStepThread androidRunStepThread = (AndroidRunStepThread) thread;
-            androidRunStepThread.setStopped(true);
+            RunStepThread runStepThread = (RunStepThread) thread;
+            runStepThread.setStopped(true);
         }
         childThreadsMap.remove(key);
     }

--- a/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
@@ -1,6 +1,7 @@
 package org.cloud.sonic.agent.tests;
 
 import org.cloud.sonic.agent.interfaces.PlatformType;
+import org.cloud.sonic.agent.tests.android.AndroidRunStepThread;
 import org.cloud.sonic.agent.tests.android.AndroidTestTaskBootThread;
 import org.cloud.sonic.agent.tests.ios.IOSTestTaskBootThread;
 import org.slf4j.Logger;
@@ -201,13 +202,14 @@ public class TaskManager {
      *
      * @param key  子线程key
      */
-    public static void forceStopChildThread(String key) {
+    public static void forceStopDebugStepThread(String key) {
         Set<Thread> threads = childThreadsMap.get(key);
         if (threads == null) {
             return;
         }
         for (Thread thread : threads) {
-            thread.stop();
+            AndroidRunStepThread androidRunStepThread = (AndroidRunStepThread) thread;
+            androidRunStepThread.setStopped(true);
         }
         childThreadsMap.remove(key);
     }

--- a/src/main/java/org/cloud/sonic/agent/tests/android/AndroidRunStepThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/android/AndroidRunStepThread.java
@@ -24,6 +24,16 @@ public class AndroidRunStepThread extends Thread {
 
     private final AndroidTestTaskBootThread androidTestTaskBootThread;
 
+    private volatile boolean stopped = false;
+
+    public boolean isStopped() {
+        return stopped;
+    }
+
+    public void setStopped(boolean stopped) {
+        this.stopped = stopped;
+    }
+
     public AndroidRunStepThread(AndroidTestTaskBootThread androidTestTaskBootThread) {
         this.androidTestTaskBootThread = androidTestTaskBootThread;
 
@@ -42,6 +52,9 @@ public class AndroidRunStepThread extends Thread {
         List<JSONObject> steps = jsonObject.getJSONArray("steps").toJavaList(JSONObject.class);
 
         for (JSONObject step : steps) {
+            if (stopped) {
+                return;
+            }
             try {
                 androidStepHandler.runStep(step);
             } catch (Throwable e) {

--- a/src/main/java/org/cloud/sonic/agent/tests/android/AndroidRunStepThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/android/AndroidRunStepThread.java
@@ -2,6 +2,7 @@ package org.cloud.sonic.agent.tests.android;
 
 import com.alibaba.fastjson.JSONObject;
 import org.cloud.sonic.agent.automation.AndroidStepHandler;
+import org.cloud.sonic.agent.tests.common.RunStepThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +14,7 @@ import java.util.List;
  * @author Eason(main) JayWenStar(until e1a877b7)
  * @date 2021/12/2 12:30 上午
  */
-public class AndroidRunStepThread extends Thread {
+public class AndroidRunStepThread extends RunStepThread {
 
     private final Logger log = LoggerFactory.getLogger(AndroidRunStepThread.class);
 
@@ -23,16 +24,6 @@ public class AndroidRunStepThread extends Thread {
     public final static String ANDROID_RUN_STEP_TASK_PRE = "android-run-step-task-%s-%s-%s";
 
     private final AndroidTestTaskBootThread androidTestTaskBootThread;
-
-    private volatile boolean stopped = false;
-
-    public boolean isStopped() {
-        return stopped;
-    }
-
-    public void setStopped(boolean stopped) {
-        this.stopped = stopped;
-    }
 
     public AndroidRunStepThread(AndroidTestTaskBootThread androidTestTaskBootThread) {
         this.androidTestTaskBootThread = androidTestTaskBootThread;
@@ -52,7 +43,7 @@ public class AndroidRunStepThread extends Thread {
         List<JSONObject> steps = jsonObject.getJSONArray("steps").toJavaList(JSONObject.class);
 
         for (JSONObject step : steps) {
-            if (stopped) {
+            if (isStopped()) {
                 return;
             }
             try {

--- a/src/main/java/org/cloud/sonic/agent/tests/common/RunStepThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/common/RunStepThread.java
@@ -1,0 +1,18 @@
+package org.cloud.sonic.agent.tests.common;
+
+/**
+ * @author JayWenStar
+ * @date 2022/2/11 10:49 上午
+ */
+public class RunStepThread extends Thread {
+
+    protected volatile boolean stopped = false;
+
+    public boolean isStopped() {
+        return stopped;
+    }
+
+    public void setStopped(boolean stopped) {
+        this.stopped = stopped;
+    }
+}

--- a/src/main/java/org/cloud/sonic/agent/tests/ios/IOSRunStepThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/ios/IOSRunStepThread.java
@@ -2,12 +2,13 @@ package org.cloud.sonic.agent.tests.ios;
 
 import com.alibaba.fastjson.JSONObject;
 import org.cloud.sonic.agent.automation.IOSStepHandler;
+import org.cloud.sonic.agent.tests.common.RunStepThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-public class IOSRunStepThread extends Thread {
+public class IOSRunStepThread extends RunStepThread {
 
     private final Logger log = LoggerFactory.getLogger(IOSRunStepThread.class);
 
@@ -33,6 +34,9 @@ public class IOSRunStepThread extends Thread {
         List<JSONObject> steps = jsonObject.getJSONArray("steps").toJavaList(JSONObject.class);
 
         for (JSONObject step : steps) {
+            if (isStopped()) {
+                return;
+            }
             try {
                 iosStepHandler.runStep(step);
             } catch (Throwable e) {

--- a/src/main/java/org/cloud/sonic/agent/tools/AgentTool.java
+++ b/src/main/java/org/cloud/sonic/agent/tools/AgentTool.java
@@ -40,6 +40,9 @@ public class AgentTool {
     }
 
     public static void sendByte(Session session, byte[] message) {
+        if (session == null || !session.isOpen()) {
+            return;
+        }
         synchronized (session) {
             try {
                 session.getBasicRemote().sendBinary(ByteBuffer.wrap(message));
@@ -50,6 +53,9 @@ public class AgentTool {
     }
 
     public static void sendText(Session session, String message) {
+        if (session == null || !session.isOpen()) {
+            return;
+        }
         synchronized (session) {
             try {
                 session.getBasicRemote().sendText(message);

--- a/src/main/java/org/cloud/sonic/agent/websockets/AndroidWSServer.java
+++ b/src/main/java/org/cloud/sonic/agent/websockets/AndroidWSServer.java
@@ -486,7 +486,7 @@ public class AndroidWSServer {
                     jsonDebug.put("caseId", msg.getInteger("caseId"));
                     NettyThreadPool.send(jsonDebug);
                 } else if (msg.getString("detail").equals("stopStep")) {
-                    TaskManager.forceStopChildThread(
+                    TaskManager.forceStopDebugStepThread(
                             AndroidRunStepThread.ANDROID_RUN_STEP_TASK_PRE.formatted(
                                     0, msg.getInteger("caseId"), msg.getString("udId")
                             )

--- a/src/main/java/org/cloud/sonic/agent/websockets/IOSWSServer.java
+++ b/src/main/java/org/cloud/sonic/agent/websockets/IOSWSServer.java
@@ -134,7 +134,7 @@ public class IOSWSServer {
                     jsonDebug.put("caseId", msg.getInteger("caseId"));
                     NettyThreadPool.send(jsonDebug);
                 } else if (msg.getString("detail").equals("stopStep")) {
-                    TaskManager.forceStopChildThread(
+                    TaskManager.forceStopDebugStepThread(
                             IOSRunStepThread.IOS_RUN_STEP_TASK_PRE.formatted(
                                     0, msg.getInteger("caseId"), msg.getString("udId")
                             )


### PR DESCRIPTION
中断没有用`thread.interrupt();`设置标志位，是因为如果线程处于sleep（类似强制等待的功能），调用`thread.interrupt();`后，会将线程唤醒，唤醒后的线程查看interrupted如果为true则抛出异常，抛出异常后interrupted又变为true了，所以使用自定义的标记位。