### PR TITLE
🐛: 修复录屏内存泄露

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
@@ -149,6 +149,13 @@ public class TaskManager {
      */
     public static void clearTerminatedThreadByKey(String key) {
         bootThreadsMap.remove(key);
+        Set<Thread> threads = childThreadsMap.get(key);
+        if (threads == null) {
+            return;
+        }
+        for (Thread thread : threads) {
+            thread.interrupt();
+        }
         childThreadsMap.remove(key);
     }
 

--- a/src/main/java/org/cloud/sonic/agent/tests/android/OutputSocketThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/android/OutputSocketThread.java
@@ -78,8 +78,8 @@ public class OutputSocketThread extends Thread {
             try {
                 buffer = dataQueue.take();
             } catch (InterruptedException e) {
-                log.error("获取数据流失败：{}", e.getMessage());
-                e.printStackTrace();
+                log.debug("获取数据流中断：", e);
+                return;
             }
             int len = buffer.length;
             for (int cursor = 0; cursor < len; ) {


### PR DESCRIPTION
问题来源：https://sonic-cloud.wiki/d/288  
还有个内存突增的问题没排查出来，但觉得跟泄露是两回事，先提这个