### PR TITLE
feat:增加输入框控件输入文本方法-sendKeysByActions

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
@@ -57,6 +57,7 @@ import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.springframework.util.Base64Utils;
 import org.springframework.util.FileCopyUtils;
@@ -768,6 +769,18 @@ public class AndroidStepHandler {
         }
     }
 
+    public void sendKeysByActions(HandleDes handleDes, String des, String selector, String pathValue, String keys) {
+        keys = TextHandler.replaceTrans(keys, globalParams);
+        handleDes.setStepDes("对" + des + "输入内容");
+        handleDes.setDetail("对" + selector + ": " + pathValue + " 输入: " + keys);
+        try {
+            // 修复flutter应用输入框无法sendKey的问题
+            new Actions(androidDriver).sendKeys(findEle(selector, pathValue),keys).perform();
+        } catch (Exception e) {
+            handleDes.setE(e);
+        }
+    }
+
     public void getTextAndAssert(HandleDes handleDes, String des, String selector, String pathValue, String expect) {
         handleDes.setStepDes("获取" + des + "文本");
         handleDes.setDetail("获取" + selector + ":" + pathValue + "文本");
@@ -1435,6 +1448,9 @@ public class AndroidStepHandler {
             case "id":
                 we = androidDriver.findElementById(pathValue);
                 break;
+            case "accessibilityId":
+                we = androidDriver.findElementByAccessibilityId(pathValue);
+                break;
             case "name":
                 we = androidDriver.findElementByName(pathValue);
                 break;
@@ -1504,6 +1520,10 @@ public class AndroidStepHandler {
                 break;
             case "sendKeys":
                 sendKeys(handleDes, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                        , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+                break;
+            case "sendKeysByActions":
+                sendKeysByActions(handleDes, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                         , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
                 break;
             case "getText":

--- a/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
@@ -1458,7 +1458,7 @@ public class AndroidStepHandler {
                 we = androidDriver.findElementByXPath(pathValue);
                 break;
             case "cssSelector":
-                we = androidDriver.findElementByCssSelector(pathValue);
+                we = androidDriver.findElement(By.cssSelector(pathValue));
                 break;
             case "className":
                 we = androidDriver.findElementByClassName(pathValue);

--- a/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
@@ -1472,6 +1472,21 @@ public class AndroidStepHandler {
             case "partialLinkText":
                 we = androidDriver.findElementByPartialLinkText(pathValue);
                 break;
+            case "cssSelector&text":
+                // 新增H5页面通过className+text定位控件元素
+                // value格式：van-button--default|购物车
+                List<String> values = new ArrayList<>(Arrays.asList(pathValue.split("\\|")));
+                if(values.size() >= 2) {
+                    // findElementsByClassName在高版本的chromedriver有bug，只能用cssSelector才能找到控件元素
+                    List<WebElement> els =   androidDriver.findElements(By.cssSelector(values.get(0)));
+                    for(WebElement el: els) {
+                        if(el.getText().equals(values.get(1))) {
+                            we = el;
+                            break;
+                        }
+                    }
+                }
+                break;
             default:
                 log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
                 break;

--- a/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
@@ -1472,26 +1472,32 @@ public class AndroidStepHandler {
             case "partialLinkText":
                 we = androidDriver.findElementByPartialLinkText(pathValue);
                 break;
-            case "cssSelector&text":
-                // 新增H5页面通过className+text定位控件元素
-                // value格式：van-button--default|购物车
-                List<String> values = new ArrayList<>(Arrays.asList(pathValue.split("\\|")));
-                if(values.size() >= 2) {
-                    // findElementsByClassName在高版本的chromedriver有bug，只能用cssSelector才能找到控件元素
-                    List<WebElement> els =   androidDriver.findElements(By.cssSelector(values.get(0)));
-                    for(WebElement el: els) {
-                        if(el.getText().equals(values.get(1))) {
-                            we = el;
-                            break;
-                        }
-                    }
-                }
+            case "cssSelectorAndText":
+                we = getWebElementByCssAndText(pathValue);
                 break;
             default:
                 log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
                 break;
         }
         return we;
+    }
+
+    private WebElement getWebElementByCssAndText(String pathValue) {
+        // 新增H5页面通过className+text定位控件元素
+        // value格式：van-button--default|购物车
+        WebElement element = null;
+        List<String> values = new ArrayList<>(Arrays.asList(pathValue.split("\\|")));
+        if(values.size() >= 2) {
+            // findElementsByClassName在高版本的chromedriver有bug，只能用cssSelector才能找到控件元素
+            List<WebElement> els =   androidDriver.findElements(By.cssSelector(values.get(0)));
+            for(WebElement el: els) {
+                if(el.getText().equals(values.get(1))) {
+                    element = el;
+                    break;
+                }
+            }
+        }
+        return element;
     }
 
     public void stepHold(HandleDes handleDes, int time) {


### PR DESCRIPTION
在Flutter应用上，输入框输入文本，如果使用Android Driver，以下方式无法输入文本：
`findEle(selector, pathValue).sendKeys(keys);`
需要切换为以下方式：
`new Actions(androidDriver).sendKeys(findEle(selector, pathValue),keys).perform();`