### PR TITLE
feat: 新增通过UIAutomator方法(仅限Android端/UIAutomator2引擎)定位控件元素

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
@@ -1491,6 +1491,9 @@ public class AndroidStepHandler {
             case "cssSelectorAndText":
                 we = getWebElementByCssAndText(pathValue);
                 break;
+            case "androidUIAutomator":
+                //仅限自动化引擎为UIAutomator2时生效
+                we = androidDriver.findElementByAndroidUIAutomator(pathValue);
             default:
                 log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
                 break;


### PR DESCRIPTION
场景：
安卓端目前已实现的操作步骤只有ele1滑动到ele2的滑动方式，Appium滑动方法也只有基于点到点的滑动，缺少高级滑动方法(要实现复杂列表搜索需要写大量判断步骤)，目前不足以覆盖列表滑动搜索控件需求。

参考：
android端UIAutomator控件定位方式用于处理列表搜索控件功能
https://appium.io/docs/en/writing-running-appium/tutorial/swipe/android-simple/

处理：
由于目前基于Appium获取的控件与基于UIAutomator的UISelector获取的控件无法相互转换，所以不对UIAutomator的语法再做转换，直接暴露语法输入给用户，相关UIAutomator语法直接由用户实现。

例子：
滑动列表中搜索定位包含"商品"文本的View
new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(new UiSelector().textContains("商品"))