### PR TITLE
fest: agent端支持断连后自动连接设备功能

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
+++ b/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
@@ -540,6 +540,13 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
     }
 
     /**
+     * 当与服务端重连失败后，关闭Android端ADB，以便重新启动ADB服务
+     */
+    public static void terminate(){
+        AndroidDebugBridge.terminate();
+    }
+
+    /**
      * @param udId
      * @param packageName
      * @return java.lang.String

--- a/src/main/java/org/cloud/sonic/agent/transport/TransportClient.java
+++ b/src/main/java/org/cloud/sonic/agent/transport/TransportClient.java
@@ -19,6 +19,7 @@ package org.cloud.sonic.agent.transport;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
+import com.android.ddmlib.AndroidDebugBridge;
 import com.android.ddmlib.IDevice;
 import lombok.extern.slf4j.Slf4j;
 import org.cloud.sonic.agent.automation.AndroidStepHandler;
@@ -170,6 +171,26 @@ public class TransportClient extends WebSocketClient {
                         }
                     }
                     break;
+                case "reconnect":
+                    log.info("===== 重新连接移动设备 ======");
+                    AndroidDeviceBridgeTool androidDeviceBridgeTool = null;
+                    try {
+                        androidDeviceBridgeTool = SpringTool.getBean(AndroidDeviceBridgeTool.class);
+                        log.info("===== 重新连接Android设备中 ======");
+                        androidDeviceBridgeTool.init();
+                    } catch (Exception e) {
+                        log.error("重新连接Android设备异常: " + e.getMessage());
+                    }
+                    SibTool sibTool = null;
+                    try {
+                        sibTool = SpringTool.getBean(SibTool.class);
+                        log.info("===== 重新连接iOS设备中 ======");
+                        sibTool.init();
+                    } catch (Exception e) {
+                        log.error("重新连接iOS设备异常: " + e.getMessage());
+                    }
+                    break;
+                default:
             }
         });
     }
@@ -181,6 +202,10 @@ public class TransportClient extends WebSocketClient {
         }
         if(TransportWorker.client == this) {
             TransportWorker.client = null;
+        }
+        // 关闭ADB服务，等待服务端唤醒
+        if (AndroidDebugBridge.getBridge() != null){
+            AndroidDeviceBridgeTool.terminate();
         }
     }
 


### PR DESCRIPTION
实际使用过程中，发现agent端在服务端发布完成后，设备连接需要拔插或者重启agent才能使得服务端发现设备。因此对这个问题进行了优化，实现服务端发布完成后，agent端重新连接移动设备，免去拔插操作。