### PR TITLE
bug-fix:修复服务端中断后agent设备无法自动重连的问题，并调整了equals调用的语法顺序

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/automation/AndroidStepHandler.java
@@ -271,12 +271,12 @@ public class AndroidStepHandler {
      * @date 2021/8/16 23:16
      */
     public void getPerform() {
-        if (!testPackage.equals("")) {
+        if (!"".equals(testPackage)) {
             List<String> performanceData = Arrays.asList("memoryinfo", "batteryinfo");
             for (String performName : performanceData) {
                 List<List<Object>> re = androidDriver.getPerformanceData(testPackage, performName, 1);
                 List<Integer> mem;
-                if (performName.equals("memoryinfo")) {
+                if ("memoryinfo".equals(performName)) {
                     mem = Arrays.asList(0, 1, 2, 5, 6, 7);
                 } else {
                     mem = Collections.singletonList(0);
@@ -285,7 +285,7 @@ public class AndroidStepHandler {
                 for (Integer memNum : mem) {
                     perform.put(re.get(0).get(memNum).toString(), re.get(1).get(memNum));
                 }
-                log.sendPerLog(testPackage, performName.equals("memoryinfo") ? 1 : 2, perform);
+                log.sendPerLog(testPackage, "memoryinfo".equals(performName) ? 1 : 2, perform);
             }
         }
     }
@@ -348,7 +348,7 @@ public class AndroidStepHandler {
             detail.put("xpath", indexXpath);
             for (Attribute attr : elements.get(i).attributes()) {
                 //把bounds字段拆出来解析，方便前端进行截取
-                if (attr.getKey().equals("bounds")) {
+                if ("bounds".equals(attr.getKey())) {
                     String bounds = attr.getValue().replace("][", ":");
                     String pointStart = bounds.substring(1, bounds.indexOf(":"));
                     String pointEnd = bounds.substring(bounds.indexOf(":") + 1, bounds.indexOf("]"));
@@ -1204,37 +1204,37 @@ public class AndroidStepHandler {
         if (!options.isEmpty()) {
             for (int i = options.size() - 1; i >= 0; i--) {
                 JSONObject jsonOption = (JSONObject) options.get(i);
-                if (jsonOption.getString("name").equals("sleepTime")) {
+                if ("sleepTime".equals(jsonOption.getString("name"))) {
                     sleepTime = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("systemEvent")) {
+                if ("systemEvent".equals(jsonOption.getString("name"))) {
                     systemEvent = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("tapEvent")) {
+                if ("tapEvent".equals(jsonOption.getString("name"))) {
                     tapEvent = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("longPressEvent")) {
+                if ("longPressEvent".equals(jsonOption.getString("name"))) {
                     longPressEvent = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("swipeEvent")) {
+                if ("swipeEvent".equals(jsonOption.getString("name"))) {
                     swipeEvent = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("zoomEvent")) {
+                if ("zoomEvent".equals(jsonOption.getString("name"))) {
                     zoomEvent = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("navEvent")) {
+                if ("navEvent".equals(jsonOption.getString("name"))) {
                     navEvent = jsonOption.getInteger("value");
                 }
-                if (jsonOption.getString("name").equals("isOpenH5Listener")) {
+                if ("isOpenH5Listener".equals(jsonOption.getString("name"))) {
                     isOpenH5Listener = jsonOption.getBoolean("value");
                 }
-                if (jsonOption.getString("name").equals("isOpenPackageListener")) {
+                if ("isOpenPackageListener".equals(jsonOption.getString("name"))) {
                     isOpenPackageListener = jsonOption.getBoolean("value");
                 }
-                if (jsonOption.getString("name").equals("isOpenActivityListener")) {
+                if ("isOpenActivityListener".equals(jsonOption.getString("name"))) {
                     isOpenActivityListener = jsonOption.getBoolean("value");
                 }
-                if (jsonOption.getString("name").equals("isOpenNetworkListener")) {
+                if ("isOpenNetworkListener".equals(jsonOption.getString("name"))) {
                     isOpenNetworkListener = jsonOption.getBoolean("value");
                 }
                 options.remove(options.get(i));

--- a/src/main/java/org/cloud/sonic/agent/tests/AndroidTests.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/AndroidTests.java
@@ -48,8 +48,8 @@ public class AndroidTests {
         List<JSONObject> dataProvider = new ArrayList<>();
         for (JSONObject iDevice : dataInfo.getJSONArray("device").toJavaList(JSONObject.class)) {
             String udId = iDevice.getString("udId");
-            if (AndroidDeviceBridgeTool.getIDeviceByUdId(udId) == null || !AndroidDeviceBridgeTool.getIDeviceByUdId(udId)
-                    .getState().toString().equals("ONLINE")) {
+            if (AndroidDeviceBridgeTool.getIDeviceByUdId(udId) == null || !"ONLINE".equals(AndroidDeviceBridgeTool.getIDeviceByUdId(udId)
+                    .getState().toString())) {
                 continue;
             }
             JSONObject deviceTestData = new JSONObject();

--- a/src/main/java/org/cloud/sonic/agent/tests/android/minicap/MiniCapLocalThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/android/minicap/MiniCapLocalThread.java
@@ -129,7 +129,7 @@ public class MiniCapLocalThread extends Thread {
         String size = AndroidDeviceBridgeTool.getScreenSize(iDevice);
         String vSize;
         int q = 80;
-        if (pic.equals("fixed")) {
+        if ("fixed".equals(pic)) {
             vSize = size;
             q = 40;
         } else {
@@ -179,7 +179,7 @@ public class MiniCapLocalThread extends Thread {
         if (man == null) {
             return;
         }
-        if (!suc && iDevice != null && (man.equals("Xiaomi") || man.equals("deltainno") || man.equals("HUAWEI"))) {
+        if (!suc && iDevice != null && ("Xiaomi".equals(man) || "deltainno".equals(man) || "HUAWEI".equals(man))) {
             suc = runMiniCap("Xiaomi");
             if (!suc && iDevice != null) {
                 suc = runMiniCap("Xiaomi_NW");
@@ -188,10 +188,10 @@ public class MiniCapLocalThread extends Thread {
                 }
             }
         }
-        if (!suc && iDevice != null && man.equals("vivo")) {
+        if (!suc && iDevice != null && "vivo".equals(man)) {
             suc = runMiniCap("vivo");
         }
-        if (!suc && iDevice != null && man.equals("LGE")) {
+        if (!suc && iDevice != null && "LGE".equals(man)) {
             suc = runMiniCap("LGE");
         }
         if (session != null && (!suc)) {

--- a/src/main/java/org/cloud/sonic/agent/tools/file/UploadTools.java
+++ b/src/main/java/org/cloud/sonic/agent/tools/file/UploadTools.java
@@ -48,7 +48,7 @@ public class UploadTools {
             folder.mkdirs();
         }
         File transfer;
-        if (type.equals("keepFiles") || type.equals("imageFiles")) {
+        if ("keepFiles".equals(type) || "imageFiles".equals(type)) {
             long timeMillis = Calendar.getInstance().getTimeInMillis();
             try {
                 Thumbnails.of(uploadFile)

--- a/src/main/java/org/cloud/sonic/agent/transport/TransportWorker.java
+++ b/src/main/java/org/cloud/sonic/agent/transport/TransportWorker.java
@@ -33,6 +33,8 @@ public class TransportWorker {
     public static TransportClient client = null;
     public static Boolean isKeyAuth = true;
 
+    public static Boolean reconnect = false;
+
     public static void send(JSONObject jsonObject) {
         dataQueue.offer(jsonObject);
     }

--- a/src/main/java/org/cloud/sonic/agent/websockets/IOSWSServer.java
+++ b/src/main/java/org/cloud/sonic/agent/websockets/IOSWSServer.java
@@ -176,7 +176,7 @@ public class IOSWSServer implements IIOSWSServer {
             switch (msg.getString("type")) {
                 case "screen": {
                     JSONObject appiumSettings = new JSONObject();
-                    if (msg.getString("detail").equals("low")) {
+                    if ("low".equals(msg.getString("detail"))) {
                         appiumSettings.put("mjpegServerFramerate", 50);
                         appiumSettings.put("mjpegScalingFactor", 50);
                         appiumSettings.put("mjpegServerScreenshotQuality", 10);
@@ -241,7 +241,7 @@ public class IOSWSServer implements IIOSWSServer {
                     break;
                 }
                 case "location": {
-                    if (msg.getString("detail").equals("set")) {
+                    if ("set".equals(msg.getString("detail"))) {
                         SibTool.locationSet(udId, msg.getString("long"), msg.getString("lat"));
                     } else {
                         SibTool.locationUnset(udId);
@@ -335,9 +335,9 @@ public class IOSWSServer implements IIOSWSServer {
                         case "keyEvent": {
                             if (iosDriver != null) {
                                 try {
-                                    if (msg.getString("key").equals("home") || msg.getString("key").equals("volumeup") || msg.getString("key").equals("volumedown")) {
+                                    if ("home".equals(msg.getString("key")) || "volumeup".equals(msg.getString("key")) || "volumedown".equals(msg.getString("key"))) {
                                         iosDriver.pressButton(msg.getString("key"));
-                                    } else if (msg.getString("key").equals("lock")) {
+                                    } else if ("lock".equals(msg.getString("key"))) {
                                         if (iosDriver.isLocked()) {
                                             iosDriver.unlock();
                                         } else {
@@ -427,8 +427,10 @@ public class IOSWSServer implements IIOSWSServer {
                             sendText(session, result.toJSONString());
                             break;
                         }
+                        default:
                     }
                     break;
+                default:
             }
         });
     }


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

- 修复了agent在连接服务端过程中，服务端中断后agent重连，所挂载的设备无法自动重连的问题，Android和iOS均在本地main环境下测试通过。
