### PR TITLE
fix: 将原来agent只能有一个结果rid执行，改为agent只能有一个结果rid

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/AndroidTests.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/AndroidTests.java
@@ -70,13 +70,13 @@ public class AndroidTests {
     @Test(dataProvider = "testData")
     public void run(JSONObject jsonObject) throws IOException {
         int rid = jsonObject.getInteger("rid");
-        if (TaskManager.ridRunning(rid)) {
+        String udId = jsonObject.getJSONObject("device").getString("udId");
+        if (TaskManager.ridRunning(rid, udId)) {
             logger.info("Task repeat! Maybe cause by network, ignore...");
             return;
         }
         int cid = jsonObject.getInteger("cid");
         AndroidStepHandler androidStepHandler = new AndroidStepHandler();
-        String udId = jsonObject.getJSONObject("device").getString("udId");
         JSONObject gp = jsonObject.getJSONObject("gp");
         androidStepHandler.setGlobalParams(gp);
         androidStepHandler.setTestMode(cid, rid, udId, DeviceStatus.TESTING, "");

--- a/src/main/java/org/cloud/sonic/agent/tests/IOSTests.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/IOSTests.java
@@ -72,13 +72,13 @@ public class IOSTests {
     @Test(dataProvider = "testData")
     public void run(JSONObject jsonObject) throws IOException {
         int rid = jsonObject.getInteger("rid");
-        if (TaskManager.ridRunning(rid)) {
+        String udId = jsonObject.getJSONObject("device").getString("udId");
+        if (TaskManager.ridRunning(rid, udId)) {
             logger.info("Task repeat! Maybe cause by network, ignore...");
             return;
         }
         int cid = jsonObject.getInteger("cid");
         IOSStepHandler iosStepHandler = new IOSStepHandler();
-        String udId = jsonObject.getJSONObject("device").getString("udId");
         JSONObject gp = jsonObject.getJSONObject("gp");
         iosStepHandler.setGlobalParams(gp);
         iosStepHandler.setTestMode(cid, rid, udId, DeviceStatus.TESTING, "");

--- a/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
@@ -56,7 +56,7 @@ public class TaskManager {
     /**
      * 记录正在运行的rid记录
      */
-    private static Set<Integer> runningRidSet =  Collections.synchronizedSet(new HashSet<>());
+    private static Set<String> runningRidSet =  Collections.synchronizedSet(new HashSet<>());
 
     /**
      * 记录正在运行的udId记录
@@ -65,8 +65,8 @@ public class TaskManager {
 
     private static final Lock lock = new ReentrantLock();
 
-    public static boolean ridRunning(Integer rid) {
-        return runningRidSet.contains(rid);
+    public static boolean ridRunning(Integer rid, String udId) {
+        return runningRidSet.contains(rid + "-" + udId);
     }
 
     public static boolean udIdRunning(String udId) {
@@ -83,7 +83,7 @@ public class TaskManager {
         addBootThread(bootThread.getName(), bootThread);
 
         String[] split = bootThread.getName().split("-");
-        runningRidSet.add(Integer.parseInt(split[split.length-3]));
+        runningRidSet.add(split[split.length-3] + "-" + split[split.length-1]);
         runningUdIdSet.add(split[split.length-1]);
     }
 
@@ -197,7 +197,7 @@ public class TaskManager {
         childThreadsMap.remove(key);
 
         String[] split = key.split("-");
-        runningRidSet.remove(Integer.parseInt(split[split.length-3]));
+        runningRidSet.remove(split[split.length-3] + "-" + split[split.length-1]);
         runningUdIdSet.remove(split[split.length-1]);
     }
 
@@ -216,14 +216,14 @@ public class TaskManager {
             bootThreadsMap.remove(k);
 
             String[] split = k.split("-");
-            runningRidSet.remove(Integer.parseInt(split[split.length-3]));
+            runningRidSet.remove(split[split.length-3] + "-" + split[split.length-1]);
             runningUdIdSet.remove(split[split.length-1]);
         });
         // 删除boot衍生的线程
         terminatedThread.forEach((key, value) -> {
             childThreadsMap.remove(key);
             String[] split = key.split("-");
-            runningRidSet.remove(Integer.parseInt(split[split.length-3]));
+            runningRidSet.remove(split[split.length-3] + "-" + split[split.length-1]);
             runningUdIdSet.remove(split[split.length-1]);
         });
     }
@@ -260,7 +260,7 @@ public class TaskManager {
         }
         runningTestsMap.remove(resultId + "");
 
-        runningRidSet.remove(resultId);
+        runningRidSet.remove(resultId + "-" + udId);
         runningUdIdSet.remove(udId);
     }
 


### PR DESCRIPTION
+ "-" + udId(设备序列号)

**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
解决多设备执行是串行而不是并行问题，原因是由于agent限制了相同的结果rid只能有一个执行