### PR TITLE
fix:修复iOS步骤执行时handleDes未使用同一个对象导致条件判断失效的问题

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/ios/IOSRunStepThread.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/ios/IOSRunStepThread.java
@@ -54,12 +54,14 @@ public class IOSRunStepThread extends RunStepThread {
         JSONObject jsonObject = iosTestTaskBootThread.getJsonObject();
         List<JSONObject> steps = jsonObject.getJSONArray("steps").toJavaList(JSONObject.class);
 
+        // 复用同一个handleDes
+        HandleDes handleDes = new HandleDes();
         for (JSONObject step : steps) {
             if (isStopped()) {
                 return;
             }
             try {
-                stepHandlers.runStep(step, new HandleDes(), this);
+                stepHandlers.runStep(step, handleDes, this);
             } catch (Throwable e) {
                 break;
             }


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
此处可能是遗漏，iOSRunStepThread的handleDes每次是新建，会出现条件判断不执行的问题。改为复用同一个HandleDes对象即可。