### PR TITLE
fix M1版本获取chromedriver可能因为版本命名问题导致获取不到问题

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
+++ b/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
@@ -765,6 +765,21 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
         AndroidWebViewMap.getMap().remove(iDevice);
     }
 
+
+	private static String getM1ChromeDriver(String version) {
+		String result = "";
+		String url = String.format("https://registry.npmmirror.com/-/binary/chromedriver/%s/",version);
+		String driverList = cn.hutool.http.HttpRequest.get(url).execute().body();
+		for (Object obj : JSONArray.parseArray(driverList)) {
+			JSONObject jsonObject = JSONObject.parseObject(obj.toString());
+			String full_name = jsonObject.getString("name");
+			if (full_name.contains("m1") || full_name.contains("arm")) {
+				result = full_name.substring(full_name.indexOf("mac"), full_name.indexOf("."));
+			}
+		}
+		return result;
+	}
+
     public static File getChromeDriver(IDevice iDevice, String packageName) throws IOException {
         String chromeVersion = "";
         List<JSONObject> result = getWebView(iDevice);
@@ -792,7 +807,7 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
         String major = chromeVersion.substring(0, end);
         HttpHeaders headers = new HttpHeaders();
         ResponseEntity<String> infoEntity =
-                restTemplate.exchange(String.format("https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%d", major), HttpMethod.GET, new HttpEntity(headers), String.class);
+                restTemplate.exchange(String.format("https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%s", major), HttpMethod.GET, new HttpEntity(headers), String.class);
         if (system.contains("win")) {
             system = "win32";
         } else if (system.contains("linux")) {
@@ -800,7 +815,8 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
         } else {
             String arch = System.getProperty("os.arch").toLowerCase();
             if (arch.contains("aarch64")) {
-                system = "mac64_m1";
+				// fixme m1 arm 版本获取到版本第一 87 应提示用户更新chrome或者做其他处理
+	            system = getM1ChromeDriver(infoEntity.getBody());
             } else {
                 system = "mac64";
             }

--- a/src/main/java/org/cloud/sonic/agent/tools/file/FileTool.java
+++ b/src/main/java/org/cloud/sonic/agent/tools/file/FileTool.java
@@ -84,6 +84,8 @@ public class FileTool {
             e.printStackTrace();
         }
         if (driver != null) {
+	        driver.setExecutable(true);
+	        driver.setWritable(true);
             source.delete();
         }
         return driver;


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
2.0.0-beta M1 agent 版本 切换 WebView 报错问题，详情请看：https://sonic-cloud.wiki/d/1803-200-beta-m1-agent-webview