### PR TITLE
fix:修复runningTestsMap的key为rid导致条件判断失效遗漏用例执行的问题

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/AndroidTests.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/AndroidTests.java
@@ -83,7 +83,8 @@ public class AndroidTests {
 
         // 启动任务
         AndroidTestTaskBootThread bootThread = new AndroidTestTaskBootThread(jsonObject, androidStepHandler);
-        if (!runningTestsMap.containsKey(rid + "")) {
+        // runningTestsMap的key在rid的基础上再加上udid，避免分发到设备上的用例不均，先执行的完的用例remove rid，导致用例执行不完全的问题
+        if (!runningTestsMap.containsKey(rid + "-" + udId)) {
             logger.info("任务【{}】中断，跳过", bootThread.getName());
             return;
         }

--- a/src/main/java/org/cloud/sonic/agent/tests/IOSTests.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/IOSTests.java
@@ -85,7 +85,8 @@ public class IOSTests {
 
         // 启动任务
         IOSTestTaskBootThread bootThread = new IOSTestTaskBootThread(jsonObject, iosStepHandler);
-        if (!runningTestsMap.containsKey(rid + "")) {
+        // runningTestsMap的key在rid的基础上再加上udid，避免先执行完的会remove rid，导致用例执行不完全的问题
+        if (!runningTestsMap.containsKey(rid + "-" + udId)) {
             logger.info("任务【{}】中断，跳过", bootThread.getName());
             return;
         }

--- a/src/main/java/org/cloud/sonic/agent/tests/SuiteListener.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/SuiteListener.java
@@ -16,7 +16,6 @@
  */
 package org.cloud.sonic.agent.tests;
 
-import cn.hutool.core.util.StrUtil;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -39,7 +38,7 @@ public class SuiteListener implements ISuiteListener {
     @Override
     public void onStart(ISuite suite) {
         String runningTestsMapKey = getRunningTestsMapKey(suite);
-        if (StrUtil.isBlank(runningTestsMapKey)){
+        if (runningTestsMapKey == null || runningTestsMapKey.length() == 0){
             return;
         }
         runningTestsMap.put(runningTestsMapKey, true);
@@ -48,7 +47,7 @@ public class SuiteListener implements ISuiteListener {
     @Override
     public void onFinish(ISuite suite) {
         String runningTestsMapKey = getRunningTestsMapKey(suite);
-        if (StrUtil.isBlank(runningTestsMapKey)){
+        if (runningTestsMapKey == null || runningTestsMapKey.length() == 0){
             return;
         }
         // 加上udId，避免先完成的设备移除后，后完成的设备无法执行后续操作

--- a/src/main/java/org/cloud/sonic/agent/tests/SuiteListener.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/SuiteListener.java
@@ -17,6 +17,8 @@
 package org.cloud.sonic.agent.tests;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
 
@@ -34,13 +36,21 @@ public class SuiteListener implements ISuiteListener {
 
     @Override
     public void onStart(ISuite suite) {
-        String rid = JSON.parseObject(suite.getParameter("dataInfo")).getString("rid");
-        runningTestsMap.put(rid, true);
+        JSONObject dataInfoJson = JSON.parseObject(suite.getParameter("dataInfo"));
+        String rid = dataInfoJson.getString("rid");
+        JSONArray deviceArray = dataInfoJson.getJSONArray("device");
+        String udId = deviceArray.getJSONObject(0).getString("udId");
+        // 以rid-udId的方式形成key
+        runningTestsMap.put(rid + "-" + udId, true);
     }
 
     @Override
     public void onFinish(ISuite suite) {
-        String rid = JSON.parseObject(suite.getParameter("dataInfo")).getString("rid");
-        runningTestsMap.remove(rid);
+        JSONObject dataInfoJson = JSON.parseObject(suite.getParameter("dataInfo"));
+        String rid = dataInfoJson.getString("rid");
+        JSONArray deviceArray = dataInfoJson.getJSONArray("device");
+        String udId = deviceArray.getJSONObject(0).getString("udId");
+        // 加上udId，避免先完成的设备移除后，后完成的设备无法执行后续操作
+        runningTestsMap.remove(rid + "-" + udId);
     }
 }

--- a/src/main/java/org/cloud/sonic/agent/tests/SuiteListener.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/SuiteListener.java
@@ -61,7 +61,14 @@ public class SuiteListener implements ISuiteListener {
         if (CollectionUtils.isEmpty(deviceArray)){
             return null;
         }
-        String udId = deviceArray.getJSONObject(0).getString("udId");
+        JSONObject jsonObject = deviceArray.getJSONObject(0);
+        if (jsonObject == null){
+            return null;
+        }
+        String udId = jsonObject.getString("udId");
+        if (udId == null || udId.length() == 0){
+            return null;
+        }
         return rid + "-" + udId;
     }
 }

--- a/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/TaskManager.java
@@ -258,7 +258,7 @@ public class TaskManager {
                 }
             }
         }
-        runningTestsMap.remove(resultId + "");
+        runningTestsMap.remove(resultId + "-" + udId);
 
         runningRidSet.remove(resultId + "-" + udId);
         runningUdIdSet.remove(udId);


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
你好，实际使用用例分发执行过程中发现，多设备下分发套件用例，当设备上的用例不均时，先完成的设备会将runningTestsMap中的rid给remove，导致在同一agent上的其它设备会进入下面这个判断：
![image](https://user-images.githubusercontent.com/51112273/198233591-cd98cad9-2d29-4160-a2e1-75ef5ecccc06.png)
套件就会直接结束。造成用例执行不完全的现象，并且在运行结果出一直显示运行中
![image](https://user-images.githubusercontent.com/51112273/198233983-6028be70-530c-4360-91d3-d5fa6d6b5012.png)
修复方法：将runningTestsMap中的key由rid改为rid-udId，这样remove的时候只会remove当前设备的key，而其它设备不会造成干扰。在实践中已经做了修改，用例执行顺利完成，无遗漏现象。