### PR TITLE
Fix 当输入文本框中带有 & 符号，则会截掉 & 符号和后面的数据;

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/websockets/AndroidWSServer.java
+++ b/src/main/java/org/cloud/sonic/agent/websockets/AndroidWSServer.java
@@ -324,8 +324,12 @@ public class AndroidWSServer implements IAndroidWSServer {
                 AndroidDeviceBridgeTool.pushToCamera(iDevice, msg.getString("url"));
                 break;
             case "text":
-                ProcessCommandTool.getProcessLocalCommand("adb -s " + iDevice.getSerialNumber()
-                        + " shell app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard " + msg.getString("detail"));
+	            String cmd = "adb -s " + iDevice.getSerialNumber() + " shell app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard " + msg.getString("detail");
+	            if (msg.getString("detail").contains("&")) {
+		            String detail = msg.getString("detail").replaceAll("\\&", "\\\\&");
+		            cmd = "adb -s " + iDevice.getSerialNumber() + " shell input text " + '"' + detail + '"';
+	            }
+	            ProcessCommandTool.getProcessLocalCommand(cmd);
                 break;
             case "touch":
                 OutputStream outputStream = outputMap.get(session);


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
Fix 当输入文本框中带有 & 符号，则会截掉 & 符号和后面的数据;
【补充说明：看了源码，发现是 yadb 的问题，这里只做了 & 符号判断，如果带有 & 符号则使用原生 adb 】

![image](https://user-images.githubusercontent.com/28882742/199154789-3167489e-63c5-4d8f-9fcd-76b6d9e68124.png)
![image](https://user-images.githubusercontent.com/28882742/199154825-d0162f5e-2707-4932-a008-206c947ba7a9.png)
