### PR TITLE
feat:修改longPress 位置为元素中心;增加swipeByDefinedDirection方法,以屏幕中心为起始 位置,根据自定义像素距离,支持上滑/下滑/左滑/右滑

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -680,6 +680,75 @@ public class AndroidStepHandler {
         }
     }
 
+    public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception {
+        handleContext.setStepDes("从手机中心位置开始滑动" + distance + "像素");
+
+        String size = AndroidDeviceBridgeTool.getScreenSize(iDevice);
+        String[] winSize = size.split("x");
+        int width = BytesTool.getInt(winSize[0]);
+        int height = BytesTool.getInt(winSize[1]);
+        handleContext.setDetail("手机分辨率为：" + width + "x" + height + " 像素");
+
+        int centerX = (int) Math.ceil(width / 2.0);
+        int centerY = (int) Math.ceil(height / 2.0);
+        int targetY;
+        int targetX;
+
+        switch (slideDirection) {
+            case "up" -> {
+                targetY = centerY - distance;
+                if (targetY < 0) {
+                    throw new Exception("滑动距离超出手机顶部！");
+                }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
+                try {
+                    AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            case "down" -> {
+                targetY = centerY + distance;
+                if (targetY > height) {
+                    throw new Exception("滑动距离超出手机底部！");
+                }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
+                try {
+                    AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            case "left" -> {
+                targetX = centerX - distance;
+                if (targetX < 0) {
+                    throw new Exception("滑动距离超出手机左侧边界！");
+                }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
+                try {
+                    AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            case "right" -> {
+                targetX = centerX + distance;
+                if (targetX > width) {
+                    throw new Exception("滑动距离超出手机右侧边界！");
+                }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
+                try {
+                    AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+
+
+
     public void longPress(HandleContext handleContext, String des, String selector, String pathValue, int time) {
         handleContext.setStepDes("长按" + des);
         handleContext.setDetail("长按控件元素" + time + "毫秒 ");
@@ -687,7 +756,11 @@ public class AndroidStepHandler {
             AndroidElement webElement = findEle(selector, pathValue);
             int x = webElement.getRect().getX();
             int y = webElement.getRect().getY();
-            AndroidTouchHandler.longPress(iDevice, x, y, time);
+            int width = webElement.getRect().getWidth();
+            int height = webElement.getRect().getHeight();
+            int centerX = x + (int) Math.ceil(width / 2.0);
+            int centerY = y + (int) Math.ceil(height / 2.0);
+            AndroidTouchHandler.longPress(iDevice, centerX, centerY, time);
         } catch (Exception e) {
             handleContext.setE(e);
         }
@@ -1324,10 +1397,8 @@ public class AndroidStepHandler {
                 switch (selector) {
                     case "poco" -> pocoElement = pocoDriver.findElement(PocoSelector.POCO, pathValue);
                     case "xpath" -> pocoElement = pocoDriver.findElement(PocoSelector.XPATH, pathValue);
-                    case "cssSelector", "pocoIterator" ->
-                            pocoElement = pocoDriver.findElement(PocoSelector.CSS_SELECTOR, pathValue);
-                    default ->
-                            log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
+                    case "cssSelector", "pocoIterator" -> pocoElement = pocoDriver.findElement(PocoSelector.CSS_SELECTOR, pathValue);
+                    default -> log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
                 }
                 if (pocoElement != null) {
                     break;
@@ -1361,10 +1432,8 @@ public class AndroidStepHandler {
                 switch (selector) {
                     case "poco" -> pocoElements = pocoDriver.findElements(PocoSelector.POCO, pathValue);
                     case "xpath" -> pocoElements = pocoDriver.findElements(PocoSelector.XPATH, pathValue);
-                    case "cssSelector", "pocoIterator" ->
-                            pocoElements = pocoDriver.findElements(PocoSelector.CSS_SELECTOR, pathValue);
-                    default ->
-                            log.sendStepLog(StepType.ERROR, "查找控件元素列表失败", "这个控件元素类型: " + selector + " 不存在!!!");
+                    case "cssSelector", "pocoIterator" -> pocoElements = pocoDriver.findElements(PocoSelector.CSS_SELECTOR, pathValue);
+                    default -> log.sendStepLog(StepType.ERROR, "查找控件元素列表失败", "这个控件元素类型: " + selector + " 不存在!!!");
                 }
                 if (pocoElements != null) {
                     break;
@@ -1643,8 +1712,7 @@ public class AndroidStepHandler {
             case "linkText" -> we = chromeDriver.findElementByLinkText(pathValue);
             case "partialLinkText" -> we = chromeDriver.findElementByPartialLinkText(pathValue);
             case "cssSelectorAndText" -> we = getWebElementByCssAndText(pathValue);
-            default ->
-                    log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
+            default -> log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
         }
         return we;
     }
@@ -1659,8 +1727,7 @@ public class AndroidStepHandler {
             case "xpath" -> we = androidDriver.findElement(AndroidSelector.XPATH, pathValue);
             case "className" -> we = androidDriver.findElement(AndroidSelector.CLASS_NAME, pathValue);
             case "androidUIAutomator" -> we = androidDriver.findElement(AndroidSelector.UIAUTOMATOR, pathValue);
-            default ->
-                    log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
+            default -> log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
         }
         return we;
     }
@@ -1706,14 +1773,11 @@ public class AndroidStepHandler {
         pathValue = TextHandler.replaceTrans(pathValue, globalParams);
         switch (selector) {
             case "id" -> androidElements = androidDriver.findElementList(AndroidSelector.Id, pathValue);
-            case "accessibilityId" ->
-                    androidElements = androidDriver.findElementList(AndroidSelector.ACCESSIBILITY_ID, pathValue);
+            case "accessibilityId" -> androidElements = androidDriver.findElementList(AndroidSelector.ACCESSIBILITY_ID, pathValue);
             case "xpath" -> androidElements = androidDriver.findElementList(AndroidSelector.XPATH, pathValue);
             case "className" -> androidElements = androidDriver.findElementList(AndroidSelector.CLASS_NAME, pathValue);
-            case "androidUIAutomator" ->
-                    androidElements = androidDriver.findElementList(AndroidSelector.UIAUTOMATOR, pathValue);
-            default ->
-                    log.sendStepLog(StepType.ERROR, "查找控件元素数组失败", "这个控件元素类型: " + selector + " 不存在!!!");
+            case "androidUIAutomator" -> androidElements = androidDriver.findElementList(AndroidSelector.UIAUTOMATOR, pathValue);
+            default -> log.sendStepLog(StepType.ERROR, "查找控件元素数组失败", "这个控件元素类型: " + selector + " 不存在!!!");
         }
         return androidElements;
     }
@@ -1782,6 +1846,7 @@ public class AndroidStepHandler {
 
     public void webViewClick(HandleContext handleContext, String des, String selector, String pathValue) {
         handleContext.setStepDes("点击" + des);
+        pathValue = TextHandler.replaceTrans(pathValue, globalParams);
         handleContext.setDetail("点击" + selector + ": " + pathValue);
         try {
             findWebEle(selector, pathValue).click();
@@ -1942,51 +2007,38 @@ public class AndroidStepHandler {
             case "readText" -> readText(handleContext, step.getString("content"), step.getString("text"));
             case "clickByImg" -> clickByImg(handleContext, eleList.getJSONObject(0).getString("eleName")
                     , eleList.getJSONObject(0).getString("eleValue"));
-            case "click" ->
-                    click(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
+            case "click" -> click(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
             case "getTitle" -> getTitle(handleContext, step.getString("content"));
             case "getUrl" -> getUrl(handleContext, step.getString("content"));
             case "getActivity" -> getActivity(handleContext, step.getString("content"));
-            case "getElementAttr" ->
-                    getElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"), step.getString("content"));
-            case "logElementAttr" ->
-                    logElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"));
-            case "sendKeys" ->
-                    sendKeys(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "sendKeysByActions" ->
-                    sendKeysByActions(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "getText" ->
-                    getTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "isExistEle" ->
-                    isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
-            case "clear" ->
-                    clear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
-            case "longPress" ->
-                    longPress(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getInteger("content"));
-            case "swipe" ->
-                    swipePoint(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
-                            , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleValue"));
-            case "swipe2" ->
-                    swipe(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
-                            , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
-            case "tap" ->
-                    tap(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue"));
-            case "longPressPoint" ->
-                    longPressPoint(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
-                            , step.getInteger("content"));
+            case "getElementAttr" -> getElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"), step.getString("content"));
+            case "logElementAttr" -> logElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"));
+            case "sendKeys" -> sendKeys(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "sendKeysByActions" -> sendKeysByActions(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "getText" -> getTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "isExistEle" -> isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "clear" -> clear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
+            case "longPress" -> longPress(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getInteger("content"));
+            case "swipe" -> swipePoint(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
+                    , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleValue"));
+            case "swipe2" -> swipe(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
+                    , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
+            case "tap" -> tap(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue"));
+            case "longPressPoint" -> longPressPoint(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
+                    , step.getInteger("content"));
             case "pause" -> pause(handleContext, step.getInteger("content"));
-            case "checkImage" ->
-                    checkImage(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
-                            , step.getDouble("content"));
+            case "swipeByDefinedDirection" -> swipeByDefinedDirection(handleContext, step.getString("text"), step.getInteger("content"));
+            case "checkImage" -> checkImage(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
+                    , step.getDouble("content"));
             case "stepScreen" -> stepScreen(handleContext);
             case "openApp" -> openApp(handleContext, step.getString("text"));
             case "terminate" -> terminate(handleContext, step.getString("text"));
@@ -2005,68 +2057,47 @@ public class AndroidStepHandler {
                 String expect = TextHandler.replaceTrans(step.getString("content"), globalParams);
                 asserts(handleContext, actual, expect, step.getString("stepType"));
             }
-            case "getTextValue" ->
-                    globalParams.put(step.getString("content"), getText(handleContext, eleList.getJSONObject(0).getString("eleName")
-                            , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
+            case "getTextValue" -> globalParams.put(step.getString("content"), getText(handleContext, eleList.getJSONObject(0).getString("eleName")
+                    , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
             case "sendKeyForce" -> sendKeyForce(handleContext, step.getString("content"));
-            case "monkey" ->
-                    runMonkey(handleContext, step.getJSONObject("content"), step.getJSONArray("text").toJavaList(JSONObject.class));
-            case "publicStep" ->
-                    publicStep(handleContext, step.getString("content"), stepJSON.getJSONArray("pubSteps"));
-            case "getWebViewText" ->
-                    getWebViewTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "isExistWebViewEle" ->
-                    isExistWebViewEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
-            case "webViewClear" ->
-                    webViewClear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
-            case "webViewSendKeys" ->
-                    webViewSendKeys(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "webViewClick" ->
-                    webViewClick(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
+            case "monkey" -> runMonkey(handleContext, step.getJSONObject("content"), step.getJSONArray("text").toJavaList(JSONObject.class));
+            case "publicStep" -> publicStep(handleContext, step.getString("content"), stepJSON.getJSONArray("pubSteps"));
+            case "getWebViewText" -> getWebViewTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "isExistWebViewEle" -> isExistWebViewEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "webViewClear" -> webViewClear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
+            case "webViewSendKeys" -> webViewSendKeys(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "webViewClick" -> webViewClick(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
             case "webViewRefresh" -> webViewRefresh(handleContext);
             case "webViewBack" -> webViewBack(handleContext);
-            case "getWebViewTextValue" ->
-                    globalParams.put(step.getString("content"), getWebViewText(handleContext, eleList.getJSONObject(0).getString("eleName")
-                            , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
-            case "findElementInterval" ->
-                    setFindElementInterval(handleContext, step.getInteger("content"), step.getInteger("text"));
+            case "getWebViewTextValue" -> globalParams.put(step.getString("content"), getWebViewText(handleContext, eleList.getJSONObject(0).getString("eleName")
+                    , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
+            case "findElementInterval" -> setFindElementInterval(handleContext, step.getInteger("content"), step.getInteger("text"));
             case "runScript" -> runScript(handleContext, step.getString("content"), step.getString("text"));
-            case "setDefaultFindPocoElementInterval" ->
-                    setDefaultFindPocoElementInterval(handleContext, step.getInteger("content"), step.getInteger("text"));
-            case "startPocoDriver" ->
-                    startPocoDriver(handleContext, step.getString("content"), step.getInteger("text"));
-            case "isExistPocoEle" ->
-                    isExistPocoEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
-            case "pocoClick" ->
-                    pocoClick(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
-            case "logPocoElementAttr" ->
-                    logPocoElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"));
-            case "pocoLongPress" ->
-                    pocoLongPress(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue")
-                            , step.getInteger("content"));
-            case "pocoSwipe" ->
-                    pocoSwipe(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
-                            , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
-            case "setTheRealPositionOfTheWindow" ->
-                    setTheRealPositionOfTheWindow(handleContext, step.getString("content"));
-            case "getPocoElementAttr" ->
-                    getPocoElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"), step.getString("content"));
-            case "getPocoTextValue" ->
-                    globalParams.put(step.getString("content"), getPocoText(handleContext, eleList.getJSONObject(0).getString("eleName")
-                            , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
-            case "getPocoText" ->
-                    getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "setDefaultFindPocoElementInterval" -> setDefaultFindPocoElementInterval(handleContext, step.getInteger("content"), step.getInteger("text"));
+            case "startPocoDriver" -> startPocoDriver(handleContext, step.getString("content"), step.getInteger("text"));
+            case "isExistPocoEle" -> isExistPocoEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "pocoClick" -> pocoClick(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
+            case "logPocoElementAttr" -> logPocoElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"));
+            case "pocoLongPress" -> pocoLongPress(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue")
+                    , step.getInteger("content"));
+            case "pocoSwipe" -> pocoSwipe(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
+                    , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
+            case "setTheRealPositionOfTheWindow" -> setTheRealPositionOfTheWindow(handleContext, step.getString("content"));
+            case "getPocoElementAttr" -> getPocoElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"), step.getString("content"));
+            case "getPocoTextValue" -> globalParams.put(step.getString("content"), getPocoText(handleContext, eleList.getJSONObject(0).getString("eleName")
+                    , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
+            case "getPocoText" -> getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
             case "freezeSource" -> freezeSource(handleContext);
             case "thawSource" -> thawSource(handleContext);
             case "closePocoDriver" -> closePocoDriver(handleContext);
@@ -2074,12 +2105,10 @@ public class AndroidStepHandler {
             case "switchIgnoreMode" -> switchIgnoreMode(handleContext, step.getBoolean("content"));
             case "switchVisibleMode" -> switchVisibleMode(handleContext, step.getBoolean("content"));
             case "closeKeyboard" -> closeKeyboard(handleContext);
-            case "iteratorPocoElement" ->
-                    iteratorPocoElement(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
-            case "iteratorAndroidElement" ->
-                    iteratorAndroidElement(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"));
+            case "iteratorPocoElement" -> iteratorPocoElement(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
+            case "iteratorAndroidElement" -> iteratorAndroidElement(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"));
         }
         switchType(step, handleContext);
     }

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -680,7 +680,7 @@ public class AndroidStepHandler {
         }
     }
 
-    public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception {
+    public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception{
         handleContext.setStepDes("从手机中心位置开始滑动" + distance + "像素");
 
         String size = AndroidDeviceBridgeTool.getScreenSize(iDevice);
@@ -698,7 +698,8 @@ public class AndroidStepHandler {
             case "up" -> {
                 targetY = centerY - distance;
                 if (targetY < 0) {
-                    throw new Exception("滑动距离超出手机顶部！");
+                    targetY = 0;
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机顶部，默认取顶部边界值"+"<"+targetY+">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
@@ -709,7 +710,8 @@ public class AndroidStepHandler {
             case "down" -> {
                 targetY = centerY + distance;
                 if (targetY > height) {
-                    throw new Exception("滑动距离超出手机底部！");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机底部，默认取底部边界值"+"<"+targetY+">");
+                    targetY = height;
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
@@ -720,7 +722,8 @@ public class AndroidStepHandler {
             case "left" -> {
                 targetX = centerX - distance;
                 if (targetX < 0) {
-                    throw new Exception("滑动距离超出手机左侧边界！");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机左侧，默认取左侧边界值"+"<"+targetX+">");
+                    targetX = 0;
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
@@ -731,7 +734,8 @@ public class AndroidStepHandler {
             case "right" -> {
                 targetX = centerX + distance;
                 if (targetX > width) {
-                    throw new Exception("滑动距离超出手机右侧边界！");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机右侧，默认取右侧边界值"+"<"+targetX+">");
+                    targetX = width;
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -680,72 +680,75 @@ public class AndroidStepHandler {
         }
     }
 
-    public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception{
+    public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception {
         handleContext.setStepDes("从设备中心位置开始滑动" + distance + "像素");
 
         String size = AndroidDeviceBridgeTool.getScreenSize(iDevice);
         String[] winSize = size.split("x");
         int width = BytesTool.getInt(winSize[0]);
         int height = BytesTool.getInt(winSize[1]);
-        log.sendStepLog(StepType.INFO,"","设备分辨率为：" + width + "x" + height + " 像素");
+        log.sendStepLog(StepType.INFO, "", "设备分辨率为：" + width + "x" + height + " 像素");
 
         int centerX = (int) Math.ceil(width / 2.0);
         int centerY = (int) Math.ceil(height / 2.0);
-        int targetY = 0;
-        int targetX = 0;
+        int targetY;
+        int targetX;
 
         switch (slideDirection) {
             case "up" -> {
                 targetY = centerY - distance;
                 if (targetY < 0) {
                     targetY = 0;
-                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备顶部，默认取顶部边界值"+"<"+targetY+">");
+                    log.sendStepLog(StepType.INFO, "", "滑动距离超出设备顶部，默认取顶部边界值" + "<" + targetY + ">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
             case "down" -> {
                 targetY = centerY + distance;
                 if (targetY > height) {
-                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备底部，默认取底部边界值"+"<"+targetY+">");
                     targetY = height;
+                    log.sendStepLog(StepType.INFO, "", "滑动距离超出设备底部，默认取底部边界值" + "<" + targetY + ">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
             case "left" -> {
                 targetX = centerX - distance;
                 if (targetX < 0) {
-                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备左侧，默认取左侧边界值"+"<"+targetX+">");
                     targetX = 0;
+                    log.sendStepLog(StepType.INFO, "", "滑动距离超出设备左侧，默认取左侧边界值" + "<" + targetX + ">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }
             case "right" -> {
                 targetX = centerX + distance;
                 if (targetX > width) {
-                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备右侧，默认取右侧边界值"+"<"+targetX+">");
                     targetX = width;
+                    log.sendStepLog(StepType.INFO, "", "滑动距离超出设备右侧，默认取右侧边界值" + "<" + targetX + ">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }
             default -> throw new Exception("Sliding in this direction is not supported. Only up/down/left/right are supported!");
         }
-        handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + (targetX == 0 ? centerX : targetX) + "," + (centerY == 0 ? centerY : targetY) + ")");
     }
 
 

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -681,13 +681,13 @@ public class AndroidStepHandler {
     }
 
     public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception{
-        handleContext.setStepDes("从手机中心位置开始滑动" + distance + "像素");
+        handleContext.setStepDes("从设备中心位置开始滑动" + distance + "像素");
 
         String size = AndroidDeviceBridgeTool.getScreenSize(iDevice);
         String[] winSize = size.split("x");
         int width = BytesTool.getInt(winSize[0]);
         int height = BytesTool.getInt(winSize[1]);
-        handleContext.setDetail("手机分辨率为：" + width + "x" + height + " 像素");
+        handleContext.setDetail("设备分辨率为：" + width + "x" + height + " 像素");
 
         int centerX = (int) Math.ceil(width / 2.0);
         int centerY = (int) Math.ceil(height / 2.0);
@@ -699,7 +699,7 @@ public class AndroidStepHandler {
                 targetY = centerY - distance;
                 if (targetY < 0) {
                     targetY = 0;
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机顶部，默认取顶部边界值"+"<"+targetY+">");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备顶部，默认取顶部边界值"+"<"+targetY+">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
@@ -710,7 +710,7 @@ public class AndroidStepHandler {
             case "down" -> {
                 targetY = centerY + distance;
                 if (targetY > height) {
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机底部，默认取底部边界值"+"<"+targetY+">");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备底部，默认取底部边界值"+"<"+targetY+">");
                     targetY = height;
                 }
                 try {
@@ -722,7 +722,7 @@ public class AndroidStepHandler {
             case "left" -> {
                 targetX = centerX - distance;
                 if (targetX < 0) {
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机左侧，默认取左侧边界值"+"<"+targetX+">");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备左侧，默认取左侧边界值"+"<"+targetX+">");
                     targetX = 0;
                 }
                 try {
@@ -734,7 +734,7 @@ public class AndroidStepHandler {
             case "right" -> {
                 targetX = centerX + distance;
                 if (targetX > width) {
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出手机右侧，默认取右侧边界值"+"<"+targetX+">");
+                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备右侧，默认取右侧边界值"+"<"+targetX+">");
                     targetX = width;
                 }
                 try {

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -65,6 +65,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.JavascriptExecutor;
+
+
 
 import javax.imageio.stream.FileImageOutputStream;
 import java.io.File;
@@ -704,7 +707,7 @@ public class AndroidStepHandler {
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
@@ -717,7 +720,7 @@ public class AndroidStepHandler {
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
@@ -730,7 +733,7 @@ public class AndroidStepHandler {
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }
@@ -743,7 +746,7 @@ public class AndroidStepHandler {
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }
@@ -1809,6 +1812,20 @@ public class AndroidStepHandler {
         return element;
     }
 
+    public void webElementScrollToView(HandleContext handleContext, String des, String selector, String pathValue){
+        handleContext.setStepDes("滚动页面元素" + des + " 至顶部可见");
+        WebElement we;
+        try{
+            we = findWebEle(selector, pathValue);
+        } catch (Exception e){
+            handleContext.setE(e);
+            return;
+        }
+        JavascriptExecutor jsExe = chromeDriver;
+        jsExe.executeScript("arguments[0].scrollIntoView();", we);
+        handleContext.setDetail("控件元素" + selector + ":"+ pathValue + "滚动至页面顶部");
+    }
+
     public void isExistWebViewEle(HandleContext handleContext, String des, String selector, String pathValue, boolean expect) {
         handleContext.setStepDes("判断控件 " + des + " 是否存在");
         handleContext.setDetail("期望值：" + (expect ? "存在" : "不存在"));
@@ -2067,6 +2084,7 @@ public class AndroidStepHandler {
             case "publicStep" -> publicStep(handleContext, step.getString("content"), stepJSON.getJSONArray("pubSteps"));
             case "getWebViewText" -> getWebViewTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                     , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "webElementScrollToView" -> webElementScrollToView(handleContext,step.getString("text"),step.getString("content"),step.getString("content"));
             case "isExistWebViewEle" -> isExistWebViewEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                     , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
             case "webViewClear" -> webViewClear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -687,7 +687,7 @@ public class AndroidStepHandler {
         String[] winSize = size.split("x");
         int width = BytesTool.getInt(winSize[0]);
         int height = BytesTool.getInt(winSize[1]);
-        handleContext.setDetail("设备分辨率为：" + width + "x" + height + " 像素");
+        log.sendStepLog(StepType.INFO,"","设备分辨率为：" + width + "x" + height + " 像素");
 
         int centerX = (int) Math.ceil(width / 2.0);
         int centerY = (int) Math.ceil(height / 2.0);
@@ -699,7 +699,7 @@ public class AndroidStepHandler {
                 targetY = centerY - distance;
                 if (targetY < 0) {
                     targetY = 0;
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备顶部，默认取顶部边界值"+"<"+targetY+">");
+                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备顶部，默认取顶部边界值"+"<"+targetY+">");
                 }
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
@@ -710,7 +710,7 @@ public class AndroidStepHandler {
             case "down" -> {
                 targetY = centerY + distance;
                 if (targetY > height) {
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备底部，默认取底部边界值"+"<"+targetY+">");
+                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备底部，默认取底部边界值"+"<"+targetY+">");
                     targetY = height;
                 }
                 try {
@@ -722,7 +722,7 @@ public class AndroidStepHandler {
             case "left" -> {
                 targetX = centerX - distance;
                 if (targetX < 0) {
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备左侧，默认取左侧边界值"+"<"+targetX+">");
+                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备左侧，默认取左侧边界值"+"<"+targetX+">");
                     targetX = 0;
                 }
                 try {
@@ -734,7 +734,7 @@ public class AndroidStepHandler {
             case "right" -> {
                 targetX = centerX + distance;
                 if (targetX > width) {
-                    log.sendStepLog(StepType.INFO,"提示:","滑动距离超出设备右侧，默认取右侧边界值"+"<"+targetX+">");
+                    log.sendStepLog(StepType.INFO,"","滑动距离超出设备右侧，默认取右侧边界值"+"<"+targetX+">");
                     targetX = width;
                 }
                 try {

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -691,8 +691,8 @@ public class AndroidStepHandler {
 
         int centerX = (int) Math.ceil(width / 2.0);
         int centerY = (int) Math.ceil(height / 2.0);
-        int targetY;
-        int targetX;
+        int targetY = 0;
+        int targetX = 0;
 
         switch (slideDirection) {
             case "up" -> {
@@ -700,7 +700,6 @@ public class AndroidStepHandler {
                 if (targetY < 0) {
                     throw new Exception("滑动距离超出手机顶部！");
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
@@ -712,7 +711,6 @@ public class AndroidStepHandler {
                 if (targetY > height) {
                     throw new Exception("滑动距离超出手机底部！");
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
@@ -724,7 +722,6 @@ public class AndroidStepHandler {
                 if (targetX < 0) {
                     throw new Exception("滑动距离超出手机左侧边界！");
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
                 } catch (Exception e) {
@@ -736,20 +733,16 @@ public class AndroidStepHandler {
                 if (targetX > width) {
                     throw new Exception("滑动距离超出手机右侧边界！");
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
                 try {
                     AndroidTouchHandler.swipe(iDevice, centerX, centerY, targetX, centerY);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
             }
-            default -> {
-                throw new Exception("Sliding in this direction is not supported. Only up/down/left/right are supported!");
-            }
+            default -> throw new Exception("Sliding in this direction is not supported. Only up/down/left/right are supported!");
         }
+        handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + (targetX == 0 ? centerX : targetX) + "," + (centerY == 0 ? centerY : targetY) + ")");
     }
-
-
 
 
     public void longPress(HandleContext handleContext, String des, String selector, String pathValue, int time) {

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -743,6 +743,9 @@ public class AndroidStepHandler {
                     e.printStackTrace();
                 }
             }
+            default -> {
+                throw new Exception("Sliding in this direction is not supported. Only up/down/left/right are supported!");
+            }
         }
     }
 

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -566,7 +566,7 @@ public class IOSStepHandler {
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
 
             }
-            // 左滑或者右滑起始点x位置的坐标接为最大值或最小值，用来解决滑动距离太短无法翻页等的操作
+            // 左滑或者右滑起始点x位置的坐标为最大值或最小值，用来解决滑动距离太短无法翻页等的操作
             case "left" -> {
                 targetX = centerX - distance;
                 if (targetX < 0) {

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -547,7 +547,7 @@ public class IOSStepHandler {
                     iosDriver.swipe(centerX, centerY, centerX, targetY);
                     log.sendStepLog(StepType.INFO,"",centerX + "," + targetY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                   handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
@@ -561,7 +561,7 @@ public class IOSStepHandler {
                 try {
                     iosDriver.swipe(centerX, centerY, centerX, targetY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
 
@@ -577,7 +577,7 @@ public class IOSStepHandler {
                 try {
                     iosDriver.swipe(width, centerY, targetX, centerY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + width + "," + centerY + ")到(" + targetX + "," + centerY + ")");
 
@@ -592,7 +592,7 @@ public class IOSStepHandler {
                 try {
                     iosDriver.swipe(0, centerY, targetX, centerY);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    handleContext.setE(e);
                 }
                 handleContext.setDetail("拖动坐标(" + 0 + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -524,7 +524,7 @@ public class IOSStepHandler {
     }
 
     public void swipeByDefinedDirection(HandleContext handleContext, String slideDirection, int distance) throws Exception{
-        handleContext.setStepDes("从设备中心位置开始滑动" + distance + "像素");
+        handleContext.setStepDes("从设备中间位置开始滑动" + distance + "像素");
 
         WindowSize size = iosDriver.getWindowSize();
         int width = size.getWidth();


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
1、长按元素的方法我发现有时候并不生效，比如在长按桌面的某个程序希望它弹出一些菜单选择项时。将其长按的位置移动到元素中心位置，可解决该问题。
2、swipeByDefinedDirection 方法有两个参数：slideDirection和distance。slideDirection表示方向，支持上下左右，distance为滑动的距离(像素)。
