### PR TITLE
实现断言验证(不相等)的agent逻辑，并丰富另外三个断言类型的输出

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -501,19 +501,26 @@ public class AndroidStepHandler {
     }
 
     public void asserts(HandleContext handleContext, String actual, String expect, String type) {
-        handleContext.setDetail("真实值： " + actual + " 期望值： " + expect);
         handleContext.setStepDes("");
         try {
             switch (type) {
                 case "assertEquals" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望等于： " + expect);
                     handleContext.setStepDes("断言验证(相等)");
                     assertEquals(actual, expect);
                 }
+                case "assertNotEquals" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望不等于： " + expect);
+                    handleContext.setStepDes("断言验证(不相等)");
+                    assertNotEquals(actual, expect);
+                }
                 case "assertTrue" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望包含： " + expect);
                     handleContext.setStepDes("断言验证(包含)");
                     assertTrue(actual.contains(expect));
                 }
                 case "assertNotTrue" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望不包含： " + expect);
                     handleContext.setStepDes("断言验证(不包含)");
                     assertFalse(actual.contains(expect));
                 }
@@ -2170,7 +2177,7 @@ public class AndroidStepHandler {
             case "locationMode" -> locationMode(handleContext, step.getBoolean("content"));
             case "keyCode" -> keyCode(handleContext, step.getString("content"));
             case "keyCodeSelf" -> keyCode(handleContext, step.getInteger("content"));
-            case "assertEquals", "assertTrue", "assertNotTrue" -> {
+            case "assertEquals", "assertNotEquals", "assertTrue", "assertNotTrue" -> {
                 String actual = TextHandler.replaceTrans(step.getString("text"), globalParams);
                 String expect = TextHandler.replaceTrans(step.getString("content"), globalParams);
                 asserts(handleContext, actual, expect, step.getString("stepType"));

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -389,19 +389,26 @@ public class IOSStepHandler {
     }
 
     public void asserts(HandleContext handleContext, String actual, String expect, String type) {
-        handleContext.setDetail("真实值： " + actual + " 期望值： " + expect);
         handleContext.setStepDes("");
         try {
             switch (type) {
                 case "assertEquals" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望等于： " + expect);
                     handleContext.setStepDes("断言验证(相等)");
                     assertEquals(actual, expect);
                 }
+                case "assertNotEquals" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望不等于： " + expect);
+                    handleContext.setStepDes("断言验证(不相等)");
+                    assertNotEquals(actual, expect);
+                }
                 case "assertTrue" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望包含： " + expect);
                     handleContext.setStepDes("断言验证(包含)");
                     assertTrue(actual.contains(expect));
                 }
                 case "assertNotTrue" -> {
+                    handleContext.setDetail("真实值： " + actual + " 期望不包含： " + expect);
                     handleContext.setStepDes("断言验证(不包含)");
                     assertFalse(actual.contains(expect));
                 }
@@ -1488,7 +1495,7 @@ public class IOSStepHandler {
             case "lock" -> lock(handleContext);
             case "unLock" -> unLock(handleContext);
             case "keyCode" -> keyCode(handleContext, step.getString("content"));
-            case "assertEquals", "assertTrue", "assertNotTrue" -> {
+            case "assertEquals", "assertNotEquals", "assertTrue", "assertNotTrue" -> {
                 String actual = TextHandler.replaceTrans(step.getString("text"), globalParams);
                 String expect = TextHandler.replaceTrans(step.getString("content"), globalParams);
                 asserts(handleContext, actual, expect, step.getString("stepType"));


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

Agent增加支持：断言验证(不相等)的类型，扩充相关指令。
另外3个断言的执行输出，也丰富了一下内容，更加清晰一点。

社区有相关需求反馈，[校验断言中希望可以加个【不相等】的断言，只有不包含不太够用](https://sonic-cloud.wiki/d/2689)
我们内部的项目也有相关的需求，尝试实现了一下。

