### PR TITLE
feat:支持断言目标元素存在的数量

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -95,6 +95,9 @@ public class AndroidStepHandler {
 
     private String targetPackage = "";
 
+    // 断言元素个数，三种元素类型的定义
+    private static final int ANDROID_ELEMENT_TYPE = 1001;
+
     public String getTargetPackage() {
         return targetPackage;
     }
@@ -823,6 +826,45 @@ public class AndroidStepHandler {
         }
         try {
             assertEquals(hasEle, expect);
+        } catch (AssertionError e) {
+            handleContext.setE(e);
+        }
+    }
+
+    /**
+     * 断言元素存在个数的方法
+     *
+     * @param handleContext HandleContext
+     * @param des           元素名称
+     * @param selector      定位方式
+     * @param pathValue     定位值
+     * @param operation     操作类型
+     * @param expectedCount 期望数量
+     * @param elementType   元素的类型
+     */
+    public void isExistEleNum(HandleContext handleContext, String des, String selector, String pathValue, String operation
+            , int expectedCount, int elementType) {
+        handleContext.setStepDes("判断控件 " + des + " 存在的个数");
+        List elementList = new ArrayList<>();
+        switch (elementType) {
+            case ANDROID_ELEMENT_TYPE:
+                try {
+                    elementList = findEleList(selector, pathValue);
+                } catch (SonicRespException e) {
+                    // 查找元素不存在时会抛异常
+                } catch (Exception ignored) {
+                }
+                break;
+            default:
+                handleContext.setE(new AssertionError("未知的元素类型" + elementType + ",无法断言元素个数"));
+                break;
+        }
+        String runDetail = "期望个数：" + operation + " " + expectedCount + "，实际个数：" + " " + (elementList == null ? 0 : elementList.size());
+        handleContext.setDetail(runDetail);
+        AssertUtil assertUtil = new AssertUtil();
+        boolean isSuccess = assertUtil.assertElementNum(operation, expectedCount, elementList);
+        try {
+            assertTrue(isSuccess);
         } catch (AssertionError e) {
             handleContext.setE(e);
         }
@@ -2141,6 +2183,11 @@ public class AndroidStepHandler {
             case "isExistEle" ->
                     isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "isExistEleNum" -> isExistEleNum(handleContext, eleList.getJSONObject(0).getString("eleName"),
+                    eleList.getJSONObject(0).getString("eleType"),
+                    eleList.getJSONObject(0).getString("eleValue"),
+                    step.getString("content"),
+                    step.getInteger("text"), ANDROID_ELEMENT_TYPE);
             case "clear" ->
                     clear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"));

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -98,6 +98,7 @@ public class AndroidStepHandler {
     // 断言元素个数，三种元素类型的定义
     private static final int ANDROID_ELEMENT_TYPE = 1001;
     private static final int WEB_ELEMENT_TYPE = 1002;
+    private static final int POCO_ELEMENT_TYPE = 1003;
 
     public String getTargetPackage() {
         return targetPackage;
@@ -862,6 +863,13 @@ public class AndroidStepHandler {
                 } catch (SonicRespException e) {
                     // 查找元素不存在时会抛异常
                 } catch (Exception ignored) {
+                }
+                break;
+            case POCO_ELEMENT_TYPE:
+                try {
+                    elementList = findPocoEleList(selector, pathValue);
+                } catch (Throwable e) {
+                    // 查找元素不存在时会抛异常
                 }
                 break;
             default:
@@ -2323,6 +2331,10 @@ public class AndroidStepHandler {
             case "isExistPocoEle" ->
                     isExistPocoEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "isExistPocoEleNum" -> isExistEleNum(handleContext,
+                    eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"),
+                    step.getInteger("text"), POCO_ELEMENT_TYPE);
             case "pocoClick" ->
                     pocoClick(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"));

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AssertUtil.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AssertUtil.java
@@ -1,0 +1,57 @@
+/*
+ *   sonic-agent  Agent of Sonic Cloud Real Machine Platform.
+ *   Copyright (C) 2023 SonicCloudOrg
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published
+ *   by the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.cloud.sonic.agent.tests.handlers;
+
+import java.util.List;
+
+/**
+ * Created by fengbincao on 2023/05/20
+ */
+public class AssertUtil {
+
+    /**
+     * 数量断言，泛型方法
+     *
+     * @param operation     操作类型
+     * @param expectedCount 期望数量
+     * @param elementList   元素列表
+     * @param <T>           范型参数
+     * @return 比较结果
+     */
+    public <T> boolean assertElementNum(String operation, int expectedCount, List<T> elementList) {
+        boolean isSuccess;
+        if (elementList == null || elementList.size() == 0) {
+            isSuccess = switch (operation) {
+                case "<" -> expectedCount > 0;
+                case "<=" -> true;
+                case ">" -> false;
+                default -> expectedCount == 0;
+            };
+        } else {
+            isSuccess = switch (operation) {
+                case "<" -> elementList.size() < expectedCount;
+                case "<=" -> elementList.size() <= expectedCount;
+                case ">" -> elementList.size() > expectedCount;
+                case ">=" -> elementList.size() >= expectedCount;
+                default -> elementList.size() == expectedCount;
+            };
+        }
+        return isSuccess;
+    }
+
+}

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -86,6 +86,9 @@ public class IOSStepHandler {
     private int targetPort = 0;
     private String targetPackage = "";
 
+    private static final int IOS_ELEMENT_TYPE = 1004;
+    private static final int WEB_ELEMENT_TYPE = 1002;
+
     public String getTargetPackage() {
         return targetPackage;
     }
@@ -653,6 +656,45 @@ public class IOSStepHandler {
         }
         try {
             assertEquals(hasEle, expect);
+        } catch (AssertionError e) {
+            handleContext.setE(e);
+        }
+    }
+
+    /**
+     * 断言元素存在个数的方法
+     *
+     * @param handleContext HandleContext
+     * @param des           元素名称
+     * @param selector      定位方式
+     * @param pathValue     定位值
+     * @param operation     操作类型
+     * @param expectedCount 期望数量
+     * @param elementType   元素的类型
+     */
+    public void isExistEleNum(HandleContext handleContext, String des, String selector, String pathValue, String operation
+            , int expectedCount, int elementType) {
+        handleContext.setStepDes("判断控件 " + des + " 存在的个数");
+        List elementList = new ArrayList<>();
+        switch (elementType) {
+            case IOS_ELEMENT_TYPE:
+                try {
+                    elementList = findEleList(selector, pathValue);
+                } catch (SonicRespException e) {
+                    // 查找元素不存在时会抛异常
+                } catch (Exception ignored) {
+                }
+                break;
+            default:
+                handleContext.setE(new AssertionError("未知的元素类型" + elementType + ",无法断言元素个数"));
+                break;
+        }
+        String runDetail = "期望个数：" + operation + " " + expectedCount + "，实际个数：" + " " + (elementList == null ? 0 : elementList.size());
+        handleContext.setDetail(runDetail);
+        AssertUtil assertUtil = new AssertUtil();
+        boolean isSuccess = assertUtil.assertElementNum(operation, expectedCount, elementList);
+        try {
+            assertTrue(isSuccess);
         } catch (AssertionError e) {
             handleContext.setE(e);
         }
@@ -1463,6 +1505,11 @@ public class IOSStepHandler {
             case "isExistEle" ->
                     isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "isExistEleNum" -> isExistEleNum(handleContext, eleList.getJSONObject(0).getString("eleName"),
+                    eleList.getJSONObject(0).getString("eleType"),
+                    eleList.getJSONObject(0).getString("eleValue"),
+                    step.getString("content"),
+                    step.getInteger("text"), IOS_ELEMENT_TYPE);
             case "clear" ->
                     clear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"));

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -87,7 +87,7 @@ public class IOSStepHandler {
     private String targetPackage = "";
 
     private static final int IOS_ELEMENT_TYPE = 1004;
-    private static final int WEB_ELEMENT_TYPE = 1002;
+    private static final int POCO_ELEMENT_TYPE = 1005;
 
     public String getTargetPackage() {
         return targetPackage;
@@ -683,6 +683,13 @@ public class IOSStepHandler {
                 } catch (SonicRespException e) {
                     // 查找元素不存在时会抛异常
                 } catch (Exception ignored) {
+                }
+                break;
+            case POCO_ELEMENT_TYPE:
+                try {
+                    elementList = findPocoEleList(selector, pathValue);
+                } catch (Throwable e) {
+                    // 查找元素不存在时会抛异常
                 }
                 break;
             default:
@@ -1564,6 +1571,10 @@ public class IOSStepHandler {
             case "isExistPocoEle" ->
                     isExistPocoEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "isExistPocoEleNum" -> isExistEleNum(handleContext,
+                    eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                    , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"),
+                    step.getInteger("text"), POCO_ELEMENT_TYPE);
             case "pocoClick" ->
                     pocoClick(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"));


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

需求场景，给定的元素定位方式，在当前的视图树中，可能查找到多个。例如listVIew中的列表item，每个item的元素id均相同，即可通过这种方式，验证列表元素的个数。

数量比较目前支持五种方式：

<img width="550" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/c6361449-9166-4e3f-8100-060066ffe492">


本次pr覆盖的场景

#### (1)Android 端原生控件

<img width="669" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/ba1c3911-55ba-441b-9647-899ac0bf8b2c">

运行效果：

<img width="809" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/9403bf21-3006-4dfa-abce-af6452ae34ad">

#### (2)Android 端web上下文场景控件

<img width="660" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/75b7c7f8-6d0a-4830-9146-a847a299f878">

运行效果

<img width="794" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/4e6ecaa6-dadd-4959-b987-1928063fc3e3">

#### (3) iOS 端原生控件

<img width="804" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/ffe5d8a5-55be-45c6-a0f8-63cdd020cf8f">

#### (4) POCO定位方式控件

