### PR TITLE
feat,将原有的“验证文本”改为“断言文本”，运行指定比较方式为等于，不等于，包含，不包含四种模式，满足更丰富的应用场景

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -2234,9 +2234,6 @@ public class AndroidStepHandler {
             case "sendKeysByActions" ->
                     sendKeysByActions(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "getText" ->
-                    getTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
             case "isExistEle" ->
                     isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
@@ -2295,9 +2292,6 @@ public class AndroidStepHandler {
             case "publicStep" -> publicStep(handleContext, step.getString("content"), step.getJSONArray("pubSteps"));
             case "setDefaultFindWebViewElementInterval" ->
                     setDefaultFindWebViewElementInterval(handleContext, step.getInteger("content"), step.getInteger("text"));
-            case "getWebViewText" ->
-                    getWebViewTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
             case "webElementScrollToView" ->
                     webElementScrollToView(handleContext, step.getString("text"), step.getString("content"), step.getString("content"));
             case "isExistWebViewEle" ->
@@ -2356,9 +2350,6 @@ public class AndroidStepHandler {
             case "getPocoTextValue" ->
                     globalParams.put(step.getString("content"), getPocoText(handleContext, eleList.getJSONObject(0).getString("eleName")
                             , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
-            case "getPocoText" ->
-                    getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
             case "freezeSource" -> freezeSource(handleContext);
             case "thawSource" -> thawSource(handleContext);
             case "closePocoDriver" -> closePocoDriver(handleContext);
@@ -2375,6 +2366,16 @@ public class AndroidStepHandler {
             case "getClipperByKeyboard" ->
                     globalParams.put(step.getString("content"), getClipperByKeyboard(handleContext));
             case "setClipperByKeyboard" -> setClipperByKeyboard(handleContext, step.getString("content"));
+            // <= 2.5版本的文本断言语法(包括原生，webView，Poco三类)，保留做兼容，老版本升级上来的存量用例继续可用
+            case "getText" ->
+                    getTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "getWebViewText" ->
+                    getWebViewTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "getPocoText" ->
+                    getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
         }
         switchType(step, handleContext);
     }

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AssertUtil.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AssertUtil.java
@@ -54,4 +54,20 @@ public class AssertUtil {
         return isSuccess;
     }
 
+    public String getAssertDesc(String originOpe) {
+        switch (originOpe) {
+            case "equal" -> {
+                return "等于";
+            }
+            case "notEqual" -> {
+                return "不等于";
+            }
+            case "contain" -> {
+                return "包含";
+            }
+            default -> {
+                return "不包含";
+            }
+        }
+    }
 }

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -1506,9 +1506,6 @@ public class IOSStepHandler {
             case "sendKeys" ->
                     sendKeys(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
-            case "getText" ->
-                    getTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
             case "isExistEle" ->
                     isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
@@ -1596,9 +1593,6 @@ public class IOSStepHandler {
             case "getPocoTextValue" ->
                     globalParams.put(step.getString("content"), getPocoText(handleContext, eleList.getJSONObject(0).getString("eleName")
                             , eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")));
-            case "getPocoText" ->
-                    getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
-                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
             case "freezeSource" -> freezeSource(handleContext);
             case "thawSource" -> thawSource(handleContext);
             case "closePocoDriver" -> closePocoDriver(handleContext);
@@ -1608,6 +1602,13 @@ public class IOSStepHandler {
             case "iteratorIOSElement" ->
                     iteratorIOSElement(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"));
+            // <= 2.5版本的文本断言语法(包括原生，webView，Poco三类)，保留做兼容，老版本升级上来的存量用例继续可用
+            case "getText" ->
+                    getTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            case "getPocoText" ->
+                    getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
+                            , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
         }
         switchType(step, handleContext);
     }

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -1480,6 +1480,53 @@ public class IOSStepHandler {
         }
     }
 
+    /**
+     * >2.5.0版本，增强型的文本断言能力，支持指定断言的方式
+     *
+     * @param handleContext HandleContext
+     * @param des           元素名
+     * @param selector      元素定位方式
+     * @param pathValue     定位方式值
+     * @param operation     断言类型(equal,notEqual,contain,notContain)
+     * @param expect        期望值
+     * @param elementType   元素类型(原生，web，poco)
+     */
+    public void getElementTextAndAssertWithOperation(HandleContext handleContext, String des, String selector,
+                                                     String pathValue, String operation, String expect, int elementType) {
+        try {
+            String realValue = switch (elementType) {
+                case IOS_ELEMENT_TYPE -> getText(handleContext, des, selector, pathValue);
+                case POCO_ELEMENT_TYPE -> getPocoText(handleContext, des, selector, pathValue);
+                default -> throw new SonicRespException("未支持的元素类型" + elementType + ",无法进行文本断言");
+            };
+            if (handleContext.getE() != null) {
+                return;
+            }
+            handleContext.setStepDes("断言" + des + "文本");
+            try {
+                expect = TextHandler.replaceTrans(expect, globalParams);
+                AssertUtil assertUtil = new AssertUtil();
+                StringBuilder sbLog = new StringBuilder("真实值：");
+                sbLog.append(realValue);
+                sbLog.append("，期望 ");
+                sbLog.append(assertUtil.getAssertDesc(operation));
+                sbLog.append(" ");
+                sbLog.append(expect);
+                handleContext.setDetail(sbLog.toString());
+                switch (operation) {
+                    case "equal" -> assertEquals(realValue, expect);
+                    case "notEqual" -> assertNotEquals(realValue, expect);
+                    case "contain" -> assertTrue(realValue.contains(expect));
+                    case "notContain" -> assertFalse(realValue.contains(expect));
+                    default -> throw new SonicRespException("未支持的文本断言操作类型" + operation + ",无法进行文本断言");
+                }
+            } catch (AssertionError e) {
+                handleContext.setE(e);
+            }
+        } catch (Exception e) {
+            handleContext.setE(e);
+        }
+    }
 
     public void runStep(JSONObject stepJSON, HandleContext handleContext) throws Throwable {
         JSONObject step = stepJSON.getJSONObject("step");
@@ -1609,6 +1656,19 @@ public class IOSStepHandler {
             case "getPocoText" ->
                     getPocoTextAndAssert(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getString("content"));
+            // > 2.5版本的文本断言语法，支持指定断言的方式
+            case "assertText" -> getElementTextAndAssertWithOperation(handleContext,
+                    eleList.getJSONObject(0).getString("eleName"),
+                    eleList.getJSONObject(0).getString("eleType"),
+                    eleList.getJSONObject(0).getString("eleValue"),
+                    step.getString("content"), step.getString("text"),
+                    IOS_ELEMENT_TYPE);
+            case "assertPocoText" -> getElementTextAndAssertWithOperation(handleContext,
+                    eleList.getJSONObject(0).getString("eleName"),
+                    eleList.getJSONObject(0).getString("eleType"),
+                    eleList.getJSONObject(0).getString("eleValue"),
+                    step.getString("content"), step.getString("text"),
+                    POCO_ELEMENT_TYPE);
         }
         switchType(step, handleContext);
     }


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [ ] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [ ] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [ ] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

旧的`getText`,`getWebViewText`,`getPocoText`指令，比较文本只能支持**相等**的场景，如果想支持包含，不包含，不等于等场景，需要先取出文本到变量，然后再调用断言，比较麻烦。

本次pr对该指令做增强处理，UI效果如下：

<img width="647" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/3e8de5d6-292e-4d68-a70e-1fc5bea4c4e5">

运行效果如下：

<img width="800" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/db8c2337-ff8c-42bb-91cf-56c790ae2ca3">

旧的`getText`,`getWebViewText`,`getPocoText`指令在agent端依然保留，用户从老版本升级上来之后，老的用例依然可用，但是UI选择步骤的入口，不再提供“验证文本”的操作，统一改为使用“断言文本”

