### PR TITLE
fix:修复webElementScrollToView方法，获取控件信息传参错误导致的元素一直无法找到。

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -2372,7 +2372,9 @@ public class AndroidStepHandler {
             case "setDefaultFindWebViewElementInterval" ->
                     setDefaultFindWebViewElementInterval(handleContext, step.getInteger("content"), step.getInteger("text"));
             case "webElementScrollToView" ->
-                    webElementScrollToView(handleContext, step.getString("text"), step.getString("content"), step.getString("content"));
+                    webElementScrollToView(handleContext,  eleList.getJSONObject(0).getString("eleName"),
+                            eleList.getJSONObject(0).getString("eleType"),
+                            eleList.getJSONObject(0).getString("eleValue"));
             case "isExistWebViewEle" ->
                     isExistWebViewEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

原来的`webElementScrollToView`参数传递部分有些问题，导致元素一直无法找到。

<img width="762" alt="企业微信截图_8800f6c5-4888-4ee2-b3d8-fa155519fe8f" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/024ceddc-d935-4e7d-8bed-145300b2dcce">

修改下参数的传递逻辑。


