### PR TITLE
feat:Android与iOS端长列表的场景下，实现“滚动到指定元素”可见的能力

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -100,6 +100,10 @@ public class AndroidStepHandler {
     private static final int WEB_ELEMENT_TYPE = 1002;
     private static final int POCO_ELEMENT_TYPE = 1003;
 
+    // 屏幕的宽度与高度信息
+    private int screenWidth = 0;
+    private int screenHeight = 0;
+
     public String getTargetPackage() {
         return targetPackage;
     }
@@ -147,10 +151,16 @@ public class AndroidStepHandler {
         }
         androidDriver.getUiaClient().setGlobalTimeOut(60000);
         log.sendStepLog(StepType.PASS, "连接 UIAutomator2 Server 成功", "");
+
+        // 获取屏幕的宽度与高度
+        String screenSizeInfo = AndroidDeviceBridgeTool.getScreenSize(iDevice);
+        String[] winSize = screenSizeInfo.split("x");
+        screenWidth = BytesTool.getInt(winSize[0]);
+        screenHeight = BytesTool.getInt(winSize[1]);
         log.androidInfo("Android", iDevice.getProperty(IDevice.PROP_BUILD_VERSION),
                 iDevice.getSerialNumber(), iDevice.getProperty(IDevice.PROP_DEVICE_MANUFACTURER),
                 iDevice.getProperty(IDevice.PROP_DEVICE_MODEL),
-                AndroidDeviceBridgeTool.getScreenSize(iDevice));
+                screenSizeInfo);
     }
 
     public void switchWindowMode(HandleContext handleContext, boolean isMulti) throws SonicRespException {
@@ -812,6 +822,45 @@ public class AndroidStepHandler {
             findEle(selector, pathValue).clear();
         } catch (Exception e) {
             handleContext.setE(e);
+        }
+    }
+
+    public void scrollToEle(HandleContext handleContext, String des, String selector, String pathValue, int maxTryTime,
+                            String direction) {
+        handleContext.setStepDes(direction + "滚动到控件 " + des + " 可见");
+
+        final int xOffset = 20;
+        boolean scrollToSuccess = false;
+        int tryScrollNums = 0;
+
+        while (tryScrollNums < maxTryTime) {
+            try {
+                AndroidElement w = findEle(selector, pathValue, 1);
+                if (w != null) {
+                    scrollToSuccess = true;
+                    break;
+                }
+            } catch (Exception ignored) {
+            }
+
+            try {
+                if ("向上".equals(direction)) {
+                    AndroidTouchHandler.swipe(iDevice, xOffset, screenHeight / 3, xOffset, screenHeight * 2 / 3);
+                } else {
+                    // 向下滑动
+                    AndroidTouchHandler.swipe(iDevice, xOffset, screenHeight * 2 / 3, xOffset, screenHeight / 3);
+                }
+            } catch (Exception e) {
+                handleContext.setE(e);
+            }
+
+            tryScrollNums++;
+        }
+
+        if (scrollToSuccess) {
+            handleContext.setDetail("实际滚动：" + tryScrollNums + "次后控件" + des + "可见");
+        } else {
+            handleContext.setE(new Exception("尝试滚动：" + maxTryTime + "次后控件" + des + "依然不可见"));
         }
     }
 
@@ -1915,15 +1964,19 @@ public class AndroidStepHandler {
     }
 
     public AndroidElement findEle(String selector, String pathValue) throws SonicRespException {
+        return findEle(selector, pathValue, null);
+    }
+
+    public AndroidElement findEle(String selector, String pathValue, Integer retryTime) throws SonicRespException {
         AndroidElement we = null;
         pathValue = TextHandler.replaceTrans(pathValue, globalParams);
         switch (selector) {
             case "androidIterator" -> we = androidDriver.findElement(pathValue);
-            case "id" -> we = androidDriver.findElement(AndroidSelector.Id, pathValue);
-            case "accessibilityId" -> we = androidDriver.findElement(AndroidSelector.ACCESSIBILITY_ID, pathValue);
-            case "xpath" -> we = androidDriver.findElement(AndroidSelector.XPATH, pathValue);
-            case "className" -> we = androidDriver.findElement(AndroidSelector.CLASS_NAME, pathValue);
-            case "androidUIAutomator" -> we = androidDriver.findElement(AndroidSelector.UIAUTOMATOR, pathValue);
+            case "id" -> we = androidDriver.findElement(AndroidSelector.Id, pathValue, retryTime);
+            case "accessibilityId" -> we = androidDriver.findElement(AndroidSelector.ACCESSIBILITY_ID, pathValue, retryTime);
+            case "xpath" -> we = androidDriver.findElement(AndroidSelector.XPATH, pathValue, retryTime);
+            case "className" -> we = androidDriver.findElement(AndroidSelector.CLASS_NAME, pathValue, retryTime);
+            case "androidUIAutomator" -> we = androidDriver.findElement(AndroidSelector.UIAUTOMATOR, pathValue, retryTime);
             default ->
                     log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
         }
@@ -2326,6 +2379,12 @@ public class AndroidStepHandler {
             case "isExistEle" ->
                     isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
+            case "scrollToEle" ->
+                    scrollToEle(handleContext, eleList.getJSONObject(0).getString("eleName"),
+                            eleList.getJSONObject(0).getString("eleType"),
+                            eleList.getJSONObject(0).getString("eleValue"),
+                            step.getInteger("content"),
+                            step.getString("text"));
             case "isExistEleNum" -> isExistEleNum(handleContext, eleList.getJSONObject(0).getString("eleName"),
                     eleList.getJSONObject(0).getString("eleType"),
                     eleList.getJSONObject(0).getString("eleValue"),

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -827,7 +827,8 @@ public class AndroidStepHandler {
 
     public void scrollToEle(HandleContext handleContext, String des, String selector, String pathValue, int maxTryTime,
                             String direction) {
-        handleContext.setStepDes(direction + "滚动到控件 " + des + " 可见");
+        String directionStr = "down".equals(direction) ? "向下" : "向上";
+        handleContext.setStepDes(directionStr + "滚动到控件 " + des + " 可见");
 
         final int xOffset = 20;
         boolean scrollToSuccess = false;
@@ -844,11 +845,12 @@ public class AndroidStepHandler {
             }
 
             try {
-                if ("向上".equals(direction)) {
+                if ("up".equals(direction)) {
                     AndroidTouchHandler.swipe(iDevice, xOffset, screenHeight / 3, xOffset, screenHeight * 2 / 3);
-                } else {
-                    // 向下滑动
+                } else if ("down".equals(direction)) {
                     AndroidTouchHandler.swipe(iDevice, xOffset, screenHeight * 2 / 3, xOffset, screenHeight / 3);
+                } else {
+                    handleContext.setE(new Exception("未知的滚动到方向类型设置"));
                 }
             } catch (Exception e) {
                 handleContext.setE(e);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -740,7 +740,8 @@ public class IOSStepHandler {
 
     public void scrollToEle(HandleContext handleContext, String des, String selector, String pathValue, int maxTryTime,
                             String direction) {
-        handleContext.setStepDes(direction + "滚动到控件 " + des + " 可见");
+        String directionStr = "down".equals(direction) ? "向下" : "向上";
+        handleContext.setStepDes(directionStr + "滚动到控件 " + des + " 可见");
 
         final int xOffset = 20;
         boolean scrollToSuccess = false;
@@ -757,11 +758,12 @@ public class IOSStepHandler {
             }
 
             try {
-                if ("向上".equals(direction)) {
+                if ("up".equals(direction)) {
                     iosDriver.swipe(xOffset, screenHeight / 3, xOffset, screenHeight * 2 / 3);
+                } else if ("down".equals(direction)) {
+                    iosDriver.swipe(xOffset, screenHeight * 2 / 3, xOffset, screenHeight / 3);
                 } else {
-                    // 向下滑动
-                    iosDriver.swipe( xOffset, screenHeight * 2 / 3, xOffset, screenHeight / 3);
+                    handleContext.setE(new Exception("未知的滚动到方向类型设置"));
                 }
             } catch (Exception e) {
                 handleContext.setE(e);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -89,6 +89,10 @@ public class IOSStepHandler {
     private static final int IOS_ELEMENT_TYPE = 1004;
     private static final int POCO_ELEMENT_TYPE = 1005;
 
+    // 屏幕的宽度与高度信息
+    private int screenWidth = 0;
+    private int screenHeight = 0;
+
     public String getTargetPackage() {
         return targetPackage;
     }
@@ -130,6 +134,9 @@ public class IOSStepHandler {
             throw out;
         }
         iosDriver.getWdaClient().setGlobalTimeOut(5 * 60 * 1000);
+        WindowSize size = iosDriver.getWindowSize();
+        screenWidth = size.getWidth();
+        screenHeight = size.getHeight();
         log.sendStepLog(StepType.PASS, "连接 WebDriverAgent 成功", "");
     }
 
@@ -731,6 +738,45 @@ public class IOSStepHandler {
         }
     }
 
+    public void scrollToEle(HandleContext handleContext, String des, String selector, String pathValue, int maxTryTime,
+                            String direction) {
+        handleContext.setStepDes(direction + "滚动到控件 " + des + " 可见");
+
+        final int xOffset = 20;
+        boolean scrollToSuccess = false;
+        int tryScrollNums = 0;
+
+        while (tryScrollNums < maxTryTime) {
+            try {
+                IOSElement w = findEle(selector, pathValue, 1);
+                if (w != null) {
+                    scrollToSuccess = true;
+                    break;
+                }
+            } catch (Exception ignored) {
+            }
+
+            try {
+                if ("向上".equals(direction)) {
+                    iosDriver.swipe(xOffset, screenHeight / 3, xOffset, screenHeight * 2 / 3);
+                } else {
+                    // 向下滑动
+                    iosDriver.swipe( xOffset, screenHeight * 2 / 3, xOffset, screenHeight / 3);
+                }
+            } catch (Exception e) {
+                handleContext.setE(e);
+            }
+
+            tryScrollNums++;
+        }
+
+        if (scrollToSuccess) {
+            handleContext.setDetail("实际滚动：" + tryScrollNums + "次后控件" + des + "可见");
+        } else {
+            handleContext.setE(new Exception("尝试滚动：" + maxTryTime + "次后控件" + des + "依然不可见"));
+        }
+    }
+
     public void getElementAttr(HandleContext handleContext, String des, String selector, String pathValue, String attr, String expect) {
         handleContext.setStepDes("验证控件 " + des + " 属性");
         handleContext.setDetail("属性：" + attr + "，期望值：" + expect);
@@ -1282,19 +1328,23 @@ public class IOSStepHandler {
     }
 
     public IOSElement findEle(String selector, String pathValue) throws SonicRespException {
+        return findEle(selector, pathValue, null);
+    }
+
+    public IOSElement findEle(String selector, String pathValue, Integer retryTime) throws SonicRespException {
         IOSElement we = null;
         pathValue = TextHandler.replaceTrans(pathValue, globalParams);
         switch (selector) {
             case "iOSIterator" -> we = iosDriver.findElement(pathValue);
-            case "id" -> we = iosDriver.findElement(IOSSelector.Id, pathValue);
-            case "accessibilityId" -> we = iosDriver.findElement(IOSSelector.ACCESSIBILITY_ID, pathValue);
-            case "nsPredicate" -> we = iosDriver.findElement(IOSSelector.PREDICATE, pathValue);
-            case "name" -> we = iosDriver.findElement(IOSSelector.NAME, pathValue);
-            case "xpath" -> we = iosDriver.findElement(IOSSelector.XPATH, pathValue);
-            case "classChain" -> we = iosDriver.findElement(IOSSelector.CLASS_CHAIN, pathValue);
-            case "className" -> we = iosDriver.findElement(IOSSelector.CLASS_NAME, pathValue);
-            case "linkText" -> we = iosDriver.findElement(IOSSelector.LINK_TEXT, pathValue);
-            case "partialLinkText" -> we = iosDriver.findElement(IOSSelector.PARTIAL_LINK_TEXT, pathValue);
+            case "id" -> we = iosDriver.findElement(IOSSelector.Id, pathValue, retryTime);
+            case "accessibilityId" -> we = iosDriver.findElement(IOSSelector.ACCESSIBILITY_ID, pathValue, retryTime);
+            case "nsPredicate" -> we = iosDriver.findElement(IOSSelector.PREDICATE, pathValue, retryTime);
+            case "name" -> we = iosDriver.findElement(IOSSelector.NAME, pathValue, retryTime);
+            case "xpath" -> we = iosDriver.findElement(IOSSelector.XPATH, pathValue, retryTime);
+            case "classChain" -> we = iosDriver.findElement(IOSSelector.CLASS_CHAIN, pathValue, retryTime);
+            case "className" -> we = iosDriver.findElement(IOSSelector.CLASS_NAME, pathValue, retryTime);
+            case "linkText" -> we = iosDriver.findElement(IOSSelector.LINK_TEXT, pathValue, retryTime);
+            case "partialLinkText" -> we = iosDriver.findElement(IOSSelector.PARTIAL_LINK_TEXT, pathValue, retryTime);
             default ->
                     log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
         }
@@ -1594,6 +1644,12 @@ public class IOSStepHandler {
                     eleList.getJSONObject(0).getString("eleValue"),
                     step.getString("content"),
                     step.getInteger("text"), IOS_ELEMENT_TYPE);
+            case "scrollToEle" ->
+                    scrollToEle(handleContext, eleList.getJSONObject(0).getString("eleName"),
+                            eleList.getJSONObject(0).getString("eleType"),
+                            eleList.getJSONObject(0).getString("eleValue"),
+                            step.getInteger("content"),
+                            step.getString("text"));
             case "clear" ->
                     clear(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"));


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

需求场景，在长列表的场景下，通常需要滑动让某个元素可见，才可以进行后续的操作。但由于屏幕分辨率的问题，滑动的距离和次数很难把握。

“滚动到指定元素可见的能力”，可以允许用户指定方向，最大滑动的次数，以及目标元素。agent层会尝试每次滑动屏幕三分之一的高度，并查找目标元素是否可见，不可见则循环，直到目标元素出现，或者滑动的次数到最大的次数。

UI效果如下：

<img width="658" alt="image" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/13313b2d-d626-4f78-908f-4ba98d42b003">

