### PR TITLE
fix:修复adb shell dumpsys  window displays获取到多个mCurrentFocus时，无法正确得到当前Activity

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
+++ b/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
@@ -579,7 +579,7 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
                 String.format("dumpsys window %s", api >= 29 ? "displays" : "windows"));
         String result = "";
         try {
-            String start = cmd.substring(cmd.indexOf("mCurrentFocus="));
+            String start = cmd.substring(cmd.indexOf("mCurrentFocus=Window"));
             String end = start.substring(start.indexOf("/") + 1);
             result = end.substring(0, end.indexOf("}"));
         } catch (Exception ignored) {

--- a/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
+++ b/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
@@ -579,9 +579,13 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
                 String.format("dumpsys window %s", api >= 29 ? "displays" : "windows"));
         String result = "";
         try {
-            String start = cmd.substring(cmd.indexOf("mCurrentFocus=Window"));
-            String end = start.substring(start.indexOf("/") + 1);
-            result = end.substring(0, end.indexOf("}"));
+            Pattern pattern = Pattern.compile("mCurrentFocus=(?!null)[^,]+");
+            Matcher matcher = pattern.matcher(cmd);
+            if (matcher.find()) {
+                String start = cmd.substring(matcher.start());
+                String end = start.substring(start.indexOf("/") + 1);
+                result = end.substring(0, end.indexOf("}"));
+            }
         } catch (Exception ignored) {
         }
         if (result.length() == 0) {


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

发现部分高版本机器(Android12，13)上，无法正确获取到当前Activity，经排查发现执行

```
adb shell dumpsys  window displays
```

存在mCurrentFocus=null的场景，按现有逻辑去截取当前Activity会出现错乱。

<img width="1751" alt="企业微信截图_c16fa5a5-c641-4517-a1b5-494493abc643" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/779695c0-b9dd-4593-81d6-77d0bab7aebf">

<img width="716" alt="企业微信截图_db31299d-1178-45f2-a837-243835efbee9" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/53324a50-c7fc-4c4b-86ab-be4c1be8ce65">


