### PR TITLE
fix:修复iOS类似Monkey能力的随机事件时报错

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/bridge/ios/SibTool.java
+++ b/src/main/java/org/cloud/sonic/agent/bridge/ios/SibTool.java
@@ -511,7 +511,7 @@ public class SibTool implements ApplicationListener<ContextRefreshedEvent> {
         String s;
         while (true) {
             try {
-                if ((s = stdInput.readLine()) == null) break;
+                if (StringUtils.isEmpty(s = stdInput.readLine())) break;
             } catch (IOException e) {
                 logger.info(e.getMessage());
                 break;


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

[社区反馈](https://sonic-cloud.wiki/d/3384-v260iosmonkey)

问题原因：

<img width="2030" alt="企业微信截图_f9d9b64a-b272-4e3c-aa80-cff165452dda" src="https://github.com/SonicCloudOrg/sonic-agent/assets/15340677/308f2fa0-e345-4729-b73a-f4837da02245">

获取安装包列表时会解析出一个null对象到`getAppList`，导致方法异常：

```
    public static List<String> getAppList(String udId) {
        return getAppList(udId, null).stream().map(e->e.getString("bundleId")).collect(Collectors.toList());
    }
```