### PR TITLE
feat:Android端添加“自动授权应用”指令，指定包名后自动赋予被测应用运行时所需权限，不再出现运行时权限弹窗，避免对用例执行的干扰

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidPermissionExtractor.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidPermissionExtractor.java
@@ -1,0 +1,94 @@
+/*
+ *   sonic-agent  Agent of Sonic Cloud Real Machine Platform.
+ *   Copyright (C) 2022 SonicCloudOrg
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published
+ *   by the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.cloud.sonic.agent.tests.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Android端权限解析工具类方法
+ * Created by fengbincao on 2023/07/12
+ */
+public class AndroidPermissionExtractor {
+
+    /**
+     * 从dumpsys package的结果输出解析权限列表
+     *
+     * @param dumpsysOutput dumpsys package的结果输出
+     * @param groupNames    权限组名
+     * @param grantedState  是否获取授权状态
+     * @return 解析出的权限列表
+     */
+    public static List<AndroidPermissionItem> extractPermissions(String dumpsysOutput, List<String> groupNames,
+                                                                 Boolean grantedState) {
+        List<AndroidPermissionItem> result = new ArrayList<>();
+
+        for (String groupName : groupNames) {
+            Pattern groupPattern = Pattern.compile("^(\\s*" + Pattern.quote(groupName) + " permissions:[\\s\\S]+)", Pattern.MULTILINE);
+            Matcher groupMatcher = groupPattern.matcher(dumpsysOutput);
+
+            if (!groupMatcher.find()) {
+                continue;
+            }
+
+            String groupMatch = groupMatcher.group(1);
+            String[] lines = groupMatch.split("\n");
+
+            if (lines.length < 2) {
+                continue;
+            }
+
+            int titleIndent = lines[0].indexOf(lines[0].trim());
+
+            for (int i = 1; i < lines.length; i++) {
+                String line = lines[i];
+                int currentIndent = line.indexOf(line.trim());
+
+                if (currentIndent <= titleIndent) {
+                    break;
+                }
+
+                Pattern permissionNamePattern = Pattern.compile("android\\.\\w*\\.?permission\\.\\w+");
+                Matcher permissionNameMatcher = permissionNamePattern.matcher(line);
+
+                if (!permissionNameMatcher.find()) {
+                    continue;
+                }
+
+                String permissionName = permissionNameMatcher.group();
+                AndroidPermissionItem item = new AndroidPermissionItem(permissionName);
+
+                if (grantedState != null) {
+                    Pattern grantedStatePattern = Pattern.compile("\\bgranted=(\\w+)");
+                    Matcher grantedStateMatcher = grantedStatePattern.matcher(line);
+
+                    if (grantedStateMatcher.find()) {
+                        boolean isGranted = grantedStateMatcher.group(1).equals("true");
+                        item.setGranted(isGranted);
+                    }
+                }
+
+                result.add(item);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidPermissionItem.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidPermissionItem.java
@@ -1,0 +1,53 @@
+/*
+ *   sonic-agent  Agent of Sonic Cloud Real Machine Platform.
+ *   Copyright (C) 2022 SonicCloudOrg
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published
+ *   by the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.cloud.sonic.agent.tests.handlers;
+
+/**
+ * Android端的权限对象
+ * Created by fengbincao on 2023/07/12
+ */
+public class AndroidPermissionItem {
+
+    private final String permission;
+    private boolean granted;
+
+    public AndroidPermissionItem(String permission) {
+        this.permission = permission;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public boolean isGranted() {
+        return granted;
+    }
+
+    public void setGranted(boolean granted) {
+        this.granted = granted;
+    }
+
+    @Override
+    public String toString() {
+        return "AndroidPermissionItem{" +
+                "permission='" + permission + '\'' +
+                ", granted=" + granted +
+                '}';
+    }
+
+}

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -418,6 +418,25 @@ public class AndroidStepHandler {
         }
     }
 
+    public void appAutoGrantPermissions(HandleContext handleContext, String packageName) {
+        handleContext.setStepDes("自动授权应用");
+        String targetPackageName = TextHandler.replaceTrans(packageName, globalParams);
+        handleContext.setDetail("授权 " + targetPackageName);
+        if (iDevice != null) {
+            String dumpsysCommandStr = String.format("dumpsys package %s", targetPackageName);
+            String getDetailCommandResult = AndroidDeviceBridgeTool.executeCommand(iDevice, dumpsysCommandStr);
+            List<AndroidPermissionItem> allPermissionItems =
+                    AndroidPermissionExtractor.extractPermissions(getDetailCommandResult,
+                    Arrays.asList("install", "runtime"), true);
+            allPermissionItems.stream().filter(permissionItem -> !permissionItem.isGranted())
+                    .forEach(permissionItem -> {
+                        String curPermission = permissionItem.getPermission();
+                        String grandCommandStr = String.format("pm grant %s %s", targetPackageName, curPermission);
+                        AndroidDeviceBridgeTool.executeCommand(iDevice, grandCommandStr);
+                    });
+        }
+    }
+
     public void openApp(HandleContext handleContext, String appPackage) {
         handleContext.setStepDes("打开应用");
         appPackage = TextHandler.replaceTrans(appPackage, globalParams);
@@ -2389,6 +2408,7 @@ public class AndroidStepHandler {
         switch (step.getString("stepType")) {
             case "switchTouchMode" -> switchTouchMode(handleContext, step.getString("content"));
             case "appReset" -> appReset(handleContext, step.getString("text"));
+            case "appAutoGrantPermissions" -> appAutoGrantPermissions(handleContext, step.getString("text"));
             case "stepHold" -> stepHold(handleContext, step.getInteger("content"));
             case "toWebView" -> toWebView(handleContext, step.getString("content"), step.getString("text"));
             case "toHandle" -> toHandle(handleContext, step.getString("content"));

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -419,7 +419,7 @@ public class AndroidStepHandler {
     }
 
     public void appAutoGrantPermissions(HandleContext handleContext, String packageName) {
-        handleContext.setStepDes("自动授权应用");
+        handleContext.setStepDes("自动授权应用权限");
         String targetPackageName = TextHandler.replaceTrans(packageName, globalParams);
         handleContext.setDetail("授权 " + targetPackageName);
         if (iDevice != null) {


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

Android端6.0之后的系统，部分敏感权限系统强制要求运行时动态授权，会对用例执行产生干扰，需要自己处理。

参考Appium的启动参数`autoGrantPermissions`的实现原理，在sonic中补齐相关能力。

[appium-adb中相关实现](https://github.com/appium/appium-adb/blob/master/lib/helpers.js#L477)

