### PR TITLE
fix:修复m1系统webview版本小于87时无法下载chromeDriver的问题

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
+++ b/src/main/java/org/cloud/sonic/agent/bridge/android/AndroidDeviceBridgeTool.java
@@ -899,16 +899,21 @@ public class AndroidDeviceBridgeTool implements ApplicationListener<ContextRefre
         } else {
             String arch = System.getProperty("os.arch").toLowerCase();
             if (arch.contains("aarch64")) {
-                // fix m1 arm version obtained is lower than 87 for special processing
                 String driverList = restTemplate.exchange(String.format("https://registry.npmmirror.com/-/binary/chromedriver/%s/",
                         ChromeDriverMap.getMap().get(majorChromeVersion)), HttpMethod.GET, new HttpEntity(headers), String.class).getBody();
+                boolean findM1ChromeDriver = false;
                 for (Object obj : JSONArray.parseArray(driverList)) {
                     JSONObject jsonObject = JSONObject.parseObject(obj.toString());
                     String fullName = jsonObject.getString("name");
                     if (fullName.contains("m1") || fullName.contains("arm")) {
                         system = fullName.substring(fullName.indexOf("mac"), fullName.indexOf("."));
+                        findM1ChromeDriver = true;
                         break;
                     }
+                }
+                // <=86版本，google未提供M1架构的chromeDriver，改为固定用chromedriver_mac64.zip
+                if (!findM1ChromeDriver) {
+                    system = "mac64";
                 }
             } else {
                 system = "mac64";


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

https://registry.npmmirror.com/-/binary/chromedriver/86.0.4240.22/

当webview版本<=86时，google官方未提供M1架构对应的chromeDriver，这里修复，改为固定使用chromedriver_mac64.zip

