### PR TITLE
feat: `Android`自动化测试步骤中新增拖拽操作以及拖拽动作拆分的三个独立事件操作

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>io.github.soniccloudorg</groupId>
             <artifactId>sonic-driver-core</artifactId>
-            <version>1.1.29</version>
+            <version>1.1.30</version>
         </dependency>
         <dependency>
             <groupId>net.coobird</groupId>

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -2529,11 +2529,11 @@ public class AndroidStepHandler {
                     dragByEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
                             , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
             case "motionEvent" -> motionEventByEle(handleContext, eleList.getJSONObject(0).getString("eleName"),
-                    eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue"), eleList.getJSONObject(0).getString("text"));
+                    eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue"), step.getString("text"));
             case "motionEventByPoint" ->
                     motionEventByPoint(handleContext, eleList.getJSONObject(0).getString("eleName"),
                             eleList.getJSONObject(0).getString("eleValue"),
-                            eleList.getJSONObject(0).getString("text"));
+                            step.getString("text"));
             case "tap" ->
                     tap(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue"));
             case "longPressPoint" ->

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -70,7 +70,6 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.springframework.util.CollectionUtils;
 
 import javax.imageio.stream.FileImageOutputStream;
-import java.awt.desktop.AboutHandler;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.Future;
@@ -428,7 +427,7 @@ public class AndroidStepHandler {
             String getDetailCommandResult = AndroidDeviceBridgeTool.executeCommand(iDevice, dumpsysCommandStr);
             List<AndroidPermissionItem> allPermissionItems =
                     AndroidPermissionExtractor.extractPermissions(getDetailCommandResult,
-                            Arrays.asList("install", "runtime"), true);
+                    Arrays.asList("install", "runtime"), true);
             allPermissionItems.stream().filter(permissionItem -> !permissionItem.isGranted())
                     .forEach(permissionItem -> {
                         String curPermission = permissionItem.getPermission();
@@ -727,8 +726,8 @@ public class AndroidStepHandler {
         double x2 = Double.parseDouble(xy2.substring(0, xy2.indexOf(",")));
         double y2 = Double.parseDouble(xy2.substring(xy2.indexOf(",") + 1));
         int[] point2 = computedPoint(x2, y2);
-        handleContext.setStepDes("从" + des1 + "滑动到" + des2);
-        handleContext.setDetail("从坐标(" + point1[0] + "," + point1[1] + ")滑动到(" + point2[0] + "," + point2[1] + ")");
+        handleContext.setStepDes("滑动拖拽" + des1 + "到" + des2);
+        handleContext.setDetail("拖动坐标(" + point1[0] + "," + point1[1] + ")到(" + point2[0] + "," + point2[1] + ")");
         try {
             AndroidTouchHandler.swipe(iDevice, point1[0], point1[1], point2[0], point2[1]);
         } catch (Exception e) {
@@ -744,8 +743,8 @@ public class AndroidStepHandler {
             int y1 = webElement.getRect().getY();
             int x2 = webElement2.getRect().getX();
             int y2 = webElement2.getRect().getY();
-            handleContext.setStepDes("从" + des + "滑动到" + des2);
-            handleContext.setDetail("从坐标(" + x1 + "," + y1 + ")滑动到坐标(" + x2 + "," + y2 + ")");
+            handleContext.setStepDes("滑动拖拽" + des + "到" + des2);
+            handleContext.setDetail("拖动坐标(" + x1 + "," + y1 + ")到(" + x2 + "," + y2 + ")");
             AndroidTouchHandler.swipe(iDevice, x1, y1, x2, y2);
         } catch (Exception e) {
             handleContext.setE(e);
@@ -837,7 +836,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到坐标(" + centerX + "," + targetY + ")");
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
             case "down" -> {
                 handleContext.setStepDes("从设备中心位置向下滑动" + distance + "像素");
@@ -851,7 +850,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到(" + centerX + "," + targetY + ")");
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
             }
             case "left" -> {
                 handleContext.setStepDes("从设备中心位置向左滑动" + distance + "像素");
@@ -865,7 +864,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到(" + targetX + "," + centerY + ")");
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }
             case "right" -> {
                 handleContext.setStepDes("从设备中心位置向右滑动" + distance + "像素");
@@ -879,7 +878,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到(" + targetX + "," + centerY + ")");
+                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
             }
             default ->
                     throw new Exception("Sliding in this direction is not supported. Only up/down/left/right are supported!");
@@ -1853,7 +1852,7 @@ public class AndroidStepHandler {
     }
 
     public void obtainPocoElementAttr(HandleContext handleContext, String des, String selector, String pathValue,
-                                      String attr, String variable) {
+                                  String attr, String variable) {
         handleContext.setStepDes("获取控件 " + des + " 属性到变量");
         handleContext.setDetail("目标属性：" + attr + "，目标变量：" + variable);
         try {
@@ -2115,12 +2114,10 @@ public class AndroidStepHandler {
         switch (selector) {
             case "androidIterator" -> we = androidDriver.findElement(pathValue);
             case "id" -> we = androidDriver.findElement(AndroidSelector.Id, pathValue, retryTime);
-            case "accessibilityId" ->
-                    we = androidDriver.findElement(AndroidSelector.ACCESSIBILITY_ID, pathValue, retryTime);
+            case "accessibilityId" -> we = androidDriver.findElement(AndroidSelector.ACCESSIBILITY_ID, pathValue, retryTime);
             case "xpath" -> we = androidDriver.findElement(AndroidSelector.XPATH, pathValue, retryTime);
             case "className" -> we = androidDriver.findElement(AndroidSelector.CLASS_NAME, pathValue, retryTime);
-            case "androidUIAutomator" ->
-                    we = androidDriver.findElement(AndroidSelector.UIAUTOMATOR, pathValue, retryTime);
+            case "androidUIAutomator" -> we = androidDriver.findElement(AndroidSelector.UIAUTOMATOR, pathValue, retryTime);
             default ->
                     log.sendStepLog(StepType.ERROR, "查找控件元素失败", "这个控件元素类型: " + selector + " 不存在!!!");
         }
@@ -2512,9 +2509,10 @@ public class AndroidStepHandler {
             case "getElementAttr" ->
                     getElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"), step.getString("content"));
-            case "obtainElementAttr" -> obtainElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"),
-                    eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue"),
-                    step.getString("text"), step.getString("content"));
+            case "obtainElementAttr" ->
+                    obtainElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"),
+                            eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue"),
+                            step.getString("text"), step.getString("content"));
             case "logElementAttr" ->
                     logElementAttr(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getString("text"));
@@ -2527,11 +2525,12 @@ public class AndroidStepHandler {
             case "isExistEle" ->
                     isExistEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType")
                             , eleList.getJSONObject(0).getString("eleValue"), step.getBoolean("content"));
-            case "scrollToEle" -> scrollToEle(handleContext, eleList.getJSONObject(0).getString("eleName"),
-                    eleList.getJSONObject(0).getString("eleType"),
-                    eleList.getJSONObject(0).getString("eleValue"),
-                    step.getInteger("content"),
-                    step.getString("text"));
+            case "scrollToEle" ->
+                    scrollToEle(handleContext, eleList.getJSONObject(0).getString("eleName"),
+                            eleList.getJSONObject(0).getString("eleType"),
+                            eleList.getJSONObject(0).getString("eleValue"),
+                            step.getInteger("content"),
+                            step.getString("text"));
             case "isExistEleNum" -> isExistEleNum(handleContext, eleList.getJSONObject(0).getString("eleName"),
                     eleList.getJSONObject(0).getString("eleType"),
                     eleList.getJSONObject(0).getString("eleValue"),

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -760,7 +760,7 @@ public class AndroidStepHandler {
         double x2 = Double.parseDouble(xy2.substring(0, xy2.indexOf(",")));
         double y2 = Double.parseDouble(xy2.substring(xy2.indexOf(",") + 1));
         int[] point2 = computedPoint(x2, y2);
-        handleContext.setStepDes("模拟长按目标" + des1 + "然后拖拽移动到" + des2 + "松手");
+        handleContext.setStepDes("模拟长按「" + des1 + "」然后拖拽移动到「" + des2 + "」松手");
         handleContext.setDetail("拖拽坐标(" + point1[0] + "," + point1[1] + ")的元素移动到(" + point2[0] + "," + point2[1] + ")");
         try {
             AndroidTouchHandler.drag(iDevice, point1[0], point1[1], point2[0], point2[1]);
@@ -777,7 +777,7 @@ public class AndroidStepHandler {
             int y1 = webElement.getRect().getY();
             int x2 = webElement2.getRect().getX();
             int y2 = webElement2.getRect().getY();
-            handleContext.setStepDes("模拟长按目标" + des + "然后拖拽移动到" + des2 + "松手");
+            handleContext.setStepDes("模拟长按「" + des + "」然后拖拽移动到「" + des2 + "」松手");
             handleContext.setDetail("拖拽坐标(" + x1 + "," + y1 + ")的元素移动到(" + x2 + "," + y2 + ")");
             AndroidTouchHandler.drag(iDevice, x1, y1, x2, y2);
         } catch (SonicRespException e) {

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -760,8 +760,8 @@ public class AndroidStepHandler {
         double x2 = Double.parseDouble(xy2.substring(0, xy2.indexOf(",")));
         double y2 = Double.parseDouble(xy2.substring(xy2.indexOf(",") + 1));
         int[] point2 = computedPoint(x2, y2);
-        handleContext.setStepDes("拖拽" + des1 + "到" + des2);
-        handleContext.setDetail("拖拽坐标(" + point1[0] + "," + point1[1] + ")到(" + point2[0] + "," + point2[1] + ")");
+        handleContext.setStepDes("模拟长按目标" + des1 + "然后拖拽移动到" + des2 + "松手");
+        handleContext.setDetail("拖拽坐标(" + point1[0] + "," + point1[1] + ")的元素移动到(" + point2[0] + "," + point2[1] + ")");
         try {
             AndroidTouchHandler.drag(iDevice, point1[0], point1[1], point2[0], point2[1]);
         } catch (Exception e) {
@@ -777,8 +777,8 @@ public class AndroidStepHandler {
             int y1 = webElement.getRect().getY();
             int x2 = webElement2.getRect().getX();
             int y2 = webElement2.getRect().getY();
-            handleContext.setStepDes("拖拽" + des + "到" + des2);
-            handleContext.setDetail("拖拽坐标(" + x1 + "," + y1 + ")到(" + x2 + "," + y2 + ")");
+            handleContext.setStepDes("模拟长按目标" + des + "然后拖拽移动到" + des2 + "松手");
+            handleContext.setDetail("拖拽坐标(" + x1 + "," + y1 + ")的元素移动到(" + x2 + "," + y2 + ")");
             AndroidTouchHandler.drag(iDevice, x1, y1, x2, y2);
         } catch (SonicRespException e) {
             handleContext.setE(e);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -721,8 +721,8 @@ public class AndroidStepHandler {
         double x2 = Double.parseDouble(xy2.substring(0, xy2.indexOf(",")));
         double y2 = Double.parseDouble(xy2.substring(xy2.indexOf(",") + 1));
         int[] point2 = computedPoint(x2, y2);
-        handleContext.setStepDes("滑动拖拽" + des1 + "到" + des2);
-        handleContext.setDetail("拖动坐标(" + point1[0] + "," + point1[1] + ")到(" + point2[0] + "," + point2[1] + ")");
+        handleContext.setStepDes("从" + des1 + "滑动到" + des2);
+        handleContext.setDetail("从坐标(" + point1[0] + "," + point1[1] + ")滑动到(" + point2[0] + "," + point2[1] + ")");
         try {
             AndroidTouchHandler.swipe(iDevice, point1[0], point1[1], point2[0], point2[1]);
         } catch (Exception e) {
@@ -738,10 +738,42 @@ public class AndroidStepHandler {
             int y1 = webElement.getRect().getY();
             int x2 = webElement2.getRect().getX();
             int y2 = webElement2.getRect().getY();
-            handleContext.setStepDes("滑动拖拽" + des + "到" + des2);
-            handleContext.setDetail("拖动坐标(" + x1 + "," + y1 + ")到(" + x2 + "," + y2 + ")");
+            handleContext.setStepDes("从" + des + "滑动到" + des2);
+            handleContext.setDetail("从坐标(" + x1 + "," + y1 + ")滑动到坐标(" + x2 + "," + y2 + ")");
             AndroidTouchHandler.swipe(iDevice, x1, y1, x2, y2);
         } catch (Exception e) {
+            handleContext.setE(e);
+        }
+    }
+
+    public void dragByPoint(HandleContext handleContext, String des1, String xy1, String des2, String xy2) {
+        double x1 = Double.parseDouble(xy1.substring(0, xy1.indexOf(",")));
+        double y1 = Double.parseDouble(xy1.substring(xy1.indexOf(",") + 1));
+        int[] point1 = computedPoint(x1, y1);
+        double x2 = Double.parseDouble(xy2.substring(0, xy2.indexOf(",")));
+        double y2 = Double.parseDouble(xy2.substring(xy2.indexOf(",") + 1));
+        int[] point2 = computedPoint(x2, y2);
+        handleContext.setStepDes("拖拽" + des1 + "到" + des2);
+        handleContext.setDetail("拖拽坐标(" + point1[0] + "," + point1[1] + ")到(" + point2[0] + "," + point2[1] + ")");
+        try {
+            AndroidTouchHandler.drag(iDevice, point1[0], point1[1], point2[0], point2[1]);
+        } catch (Exception e) {
+            handleContext.setE(e);
+        }
+    }
+
+    public void dragByEle(HandleContext handleContext, String des, String selector, String pathValue, String des2, String selector2, String pathValue2) {
+        try {
+            AndroidElement webElement = findEle(selector, pathValue);
+            AndroidElement webElement2 = findEle(selector2, pathValue2);
+            int x1 = webElement.getRect().getX();
+            int y1 = webElement.getRect().getY();
+            int x2 = webElement2.getRect().getX();
+            int y2 = webElement2.getRect().getY();
+            handleContext.setStepDes("拖拽" + des + "到" + des2);
+            handleContext.setDetail("拖拽坐标(" + x1 + "," + y1 + ")到(" + x2 + "," + y2 + ")");
+            AndroidTouchHandler.drag(iDevice, x1, y1, x2, y2);
+        } catch (SonicRespException e) {
             handleContext.setE(e);
         }
     }
@@ -771,7 +803,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
+                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到坐标(" + centerX + "," + targetY + ")");
             }
             case "down" -> {
                 handleContext.setStepDes("从设备中心位置向下滑动" + distance + "像素");
@@ -785,7 +817,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + centerX + "," + targetY + ")");
+                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到(" + centerX + "," + targetY + ")");
             }
             case "left" -> {
                 handleContext.setStepDes("从设备中心位置向左滑动" + distance + "像素");
@@ -799,7 +831,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
+                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到(" + targetX + "," + centerY + ")");
             }
             case "right" -> {
                 handleContext.setStepDes("从设备中心位置向右滑动" + distance + "像素");
@@ -813,7 +845,7 @@ public class AndroidStepHandler {
                 } catch (Exception e) {
                     handleContext.setE(e);
                 }
-                handleContext.setDetail("拖动坐标(" + centerX + "," + centerY + ")到(" + targetX + "," + centerY + ")");
+                handleContext.setDetail("从坐标(" + centerX + "," + centerY + ")滑动到(" + targetX + "," + centerY + ")");
             }
             default ->
                     throw new Exception("Sliding in this direction is not supported. Only up/down/left/right are supported!");
@@ -1767,7 +1799,7 @@ public class AndroidStepHandler {
     }
 
     public void obtainPocoElementAttr(HandleContext handleContext, String des, String selector, String pathValue,
-                                  String attr, String variable) {
+                                      String attr, String variable) {
         handleContext.setStepDes("获取控件 " + des + " 属性到变量");
         handleContext.setDetail("目标属性：" + attr + "，目标变量：" + variable);
         try {
@@ -2462,6 +2494,12 @@ public class AndroidStepHandler {
                             , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleValue"));
             case "swipe2" ->
                     swipe(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
+                            , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
+            case "drag" ->
+                    dragByPoint(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue")
+                            , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleValue"));
+            case "drag2" ->
+                    dragByEle(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleType"), eleList.getJSONObject(0).getString("eleValue")
                             , eleList.getJSONObject(1).getString("eleName"), eleList.getJSONObject(1).getString("eleType"), eleList.getJSONObject(1).getString("eleValue"));
             case "tap" ->
                     tap(handleContext, eleList.getJSONObject(0).getString("eleName"), eleList.getJSONObject(0).getString("eleValue"));

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -748,6 +748,8 @@ public class AndroidStepHandler {
     }
 
     public void dragByPoint(HandleContext handleContext, String des1, String xy1, String des2, String xy2) {
+        xy1 = TextHandler.replaceTrans(xy1, globalParams);
+        xy2 = TextHandler.replaceTrans(xy2, globalParams);
         double x1 = Double.parseDouble(xy1.substring(0, xy1.indexOf(",")));
         double y1 = Double.parseDouble(xy1.substring(xy1.indexOf(",") + 1));
         int[] point1 = computedPoint(x1, y1);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidTouchHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidTouchHandler.java
@@ -118,7 +118,7 @@ public class AndroidTouchHandler {
                 int[] re2 = transferWithRotation(iDevice, x2, y2);
                 writeToOutputStream(iDevice, String.format("down %d %d\n", re1[0], re1[1]));
                 try {
-                    Thread.sleep(5); // 滑动效果不需要长按300ms
+                    Thread.sleep(300);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidTouchHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidTouchHandler.java
@@ -118,7 +118,7 @@ public class AndroidTouchHandler {
                 int[] re2 = transferWithRotation(iDevice, x2, y2);
                 writeToOutputStream(iDevice, String.format("down %d %d\n", re1[0], re1[1]));
                 try {
-                    Thread.sleep(300);
+                    Thread.sleep(5); // 滑动效果不需要长按300ms
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
@@ -164,6 +164,68 @@ public class AndroidTouchHandler {
                 }
             }
             default -> throw new IllegalStateException("Unexpected value: " + getTouchMode(iDevice));
+        }
+    }
+
+    public static void drag(IDevice iDevice, int x1, int y1, int x2, int y2) throws SonicRespException {
+        drag(iDevice, x1, y1, x2, y2, DEFAULT_SWIPE_DURATION);
+    }
+
+    public static void drag(IDevice iDevice, int x1, int y1, int x2, int y2, int swipeDuration) throws SonicRespException {
+        switch (getTouchMode(iDevice)) {
+            case ADB ->
+                    AndroidDeviceBridgeTool.executeCommand(iDevice, String.format("input draganddrop %d %d %d %d %d", x1, y1, x2, y2, swipeDuration));
+            case APPIUM_UIAUTOMATOR2_SERVER -> {
+                AndroidStepHandler curStepHandler = HandlerMap.getAndroidMap().get(iDevice.getSerialNumber());
+                if (curStepHandler != null && curStepHandler.getAndroidDriver() != null) {
+                    curStepHandler.getAndroidDriver().drag(x1, y1, x2, y2, swipeDuration, null, null);
+                }
+            }
+            case SONIC_APK -> {
+                // 原本这段代码是在`swipe(IDevice iDevice, int x1, int y1, int x2, int y2, int swipeDuration)`中的
+                // 但是swipe的效果应该是在屏幕滑动，而不是在第一个坐标按下时存在延迟，所以放在drag方法里面更加符合
+                int[] re1 = transferWithRotation(iDevice, x1, y1);
+                int[] re2 = transferWithRotation(iDevice, x2, y2);
+                writeToOutputStream(iDevice, String.format("down %d %d\n", re1[0], re1[1]));
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                long startTime = System.currentTimeMillis();
+                while (true) {
+                    // 当前时间
+                    long currentTime = System.currentTimeMillis();
+                    // 计算时间进度
+                    float timeProgress = (currentTime - startTime) / (float) swipeDuration;
+                    if (timeProgress >= 1.0f) {
+                        // 已经过渡到结束值，停止过渡
+                        writeToOutputStream(iDevice, String.format("move %d %d\n", re2[0], re2[1]));
+                        break;
+                    }
+                    BiFunction<Integer, Integer, Integer> transitionX = (start, end) ->
+                            (int) (start + (end - start) * timeProgress);
+                    BiFunction<Integer, Integer, Integer> transitionY = (start, end) ->
+                            (int) (start + (end - start) * timeProgress);
+
+                    int currentX = transitionX.apply(re1[0], re2[0]);
+                    int currentY = transitionY.apply(re1[1], re2[1]);
+                    // 使用当前坐标进行操作
+                    writeToOutputStream(iDevice, String.format("move %d %d\n", currentX, currentY));
+                    try {
+                        Thread.sleep(5);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                writeToOutputStream(iDevice, "up\n");
+            }
+
         }
     }
 

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidTouchHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidTouchHandler.java
@@ -229,6 +229,23 @@ public class AndroidTouchHandler {
         }
     }
 
+    public static void motionEvent(IDevice iDevice, String motionEventType, int x1, int y1) throws SonicRespException {
+        switch (getTouchMode(iDevice)) {
+            case ADB ->
+                    AndroidDeviceBridgeTool.executeCommand(iDevice, String.format("input motionevent %s %d %d", motionEventType, x1, y1));
+            case SONIC_APK -> {
+                int[] re1 = transferWithRotation(iDevice, x1, y1);
+                writeToOutputStream(iDevice, String.format("%s %d %d\n", motionEventType.toLowerCase(), re1[0], re1[1]));
+            }
+            case APPIUM_UIAUTOMATOR2_SERVER -> {
+                AndroidStepHandler curStepHandler = HandlerMap.getAndroidMap().get(iDevice.getSerialNumber());
+                if (curStepHandler != null && curStepHandler.getAndroidDriver() != null) {
+                    curStepHandler.getAndroidDriver().touchAction(motionEventType.toLowerCase(), x1, y1);
+                }
+            }
+        }
+    }
+
     private static int[] transferWithRotation(IDevice iDevice, int x, int y) {
         Integer directionStatus = AndroidDeviceManagerMap.getRotationMap().get(iDevice.getSerialNumber());
         if (directionStatus == null) {


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
- 原pr：https://github.com/SonicCloudOrg/sonic-agent/pull/447
#### 整体内容描述：
1. 对接driver新增uia模式的拖拽（drag）、touchAction
2. 对原来swipe相关方法中出现`拖拽`词语的进行纠正为`滑动`

#### 为什么要增加touchAction?
- 考虑有些拖拽目标定位是在长按图标之后才会出现的，所以将拖拽3个步骤拆成独立步骤，经过测试长按之后接拖拽事件也是可以的

#### 功能测试
1. 3个模式下，drag操作均符合预期
2. motionEvent(即touchAction)中down、up操作基本符合预期
4. adb模式下，move motionEvent符合预期，uia和sonic模式会出现卡顿，即划线过程中会出现一次停顿 
![image](https://github.com/SonicCloudOrg/sonic-agent/assets/44832826/ace68864-538e-4e73-bfa8-6a151c615372)
5. motionEvent，在手机桌面上操作图片拖拽，有可能需要执行两次move操作，图标才会移动，可能是机型差异，而在微信小程序菜单中则不会出现这个问题

###### 对应前端：https://github.com/SonicCloudOrg/sonic-client-web/pull/284
