### PR TITLE
feat: 自动化步骤中坐标相关操作的控件元素也可以使用参数化&安卓获取控件属性时可直接获取中心坐标值

### DIFF
--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -1021,6 +1021,16 @@ public class AndroidStepHandler {
         handleContext.setStepDes("获取控件 " + des + " 属性到变量");
         handleContext.setDetail("目标属性：" + attr + "，目标变量：" + variable);
         try {
+            // 自定义一个获取控件中心坐标的逻辑，方便通过控件获取一个坐标去做滑动、拖拽等操作
+            if (attr.equals("centerCoordinate")) {
+                String bounds = findEle(selector, pathValue).getAttribute("bounds"); // [x1,y1][x2,y2]
+                String[] parts = bounds.split("]\\[");
+                String[] xy = parts[0].substring(1).split(",");
+                String[] xy2 = parts[1].substring(0, parts[1].length() - 1).split(",");
+                String attrValue = (Integer.parseInt(xy2[0]) + Integer.parseInt(xy[0])) / 2 + "," + (Integer.parseInt(xy2[1]) + Integer.parseInt(xy[1])) / 2;
+                log.sendStepLog(StepType.INFO, "", attr + " 属性获取结果: " + attrValue);
+                return;
+            }
             String attrValue = findEle(selector, pathValue).getAttribute(attr);
             log.sendStepLog(StepType.INFO, "", attr + " 属性获取结果: " + attrValue);
             globalParams.put(variable, attrValue);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -1003,8 +1003,14 @@ public class AndroidStepHandler {
     public void getElementAttr(HandleContext handleContext, String des, String selector, String pathValue, String attr, String expect) {
         handleContext.setStepDes("验证控件 " + des + " 属性");
         handleContext.setDetail("属性：" + attr + "，期望值：" + expect);
+        String attrValue;
         try {
-            String attrValue = findEle(selector, pathValue).getAttribute(attr);
+            if (attr.equals("centerCoordinate")) {
+                String bounds = findEle(selector, pathValue).getAttribute("bounds"); // [x1,y1][x2,y2]
+                attrValue = getCenterCoordinate(bounds);
+            } else {
+                attrValue = findEle(selector, pathValue).getAttribute(attr);
+            }
             log.sendStepLog(StepType.INFO, "", attr + " 属性获取结果: " + attrValue);
             try {
                 assertEquals(attrValue, expect);
@@ -1020,24 +1026,27 @@ public class AndroidStepHandler {
                                   String attr, String variable) {
         handleContext.setStepDes("获取控件 " + des + " 属性到变量");
         handleContext.setDetail("目标属性：" + attr + "，目标变量：" + variable);
+        String attrValue;
         try {
             // 自定义一个获取控件中心坐标的逻辑，方便通过控件获取一个坐标去做滑动、拖拽等操作
             if (attr.equals("centerCoordinate")) {
                 String bounds = findEle(selector, pathValue).getAttribute("bounds"); // [x1,y1][x2,y2]
-                String[] parts = bounds.split("]\\[");
-                String[] xy = parts[0].substring(1).split(",");
-                String[] xy2 = parts[1].substring(0, parts[1].length() - 1).split(",");
-                String attrValue = (Integer.parseInt(xy2[0]) + Integer.parseInt(xy[0])) / 2 + "," + (Integer.parseInt(xy2[1]) + Integer.parseInt(xy[1])) / 2;
-                log.sendStepLog(StepType.INFO, "", attr + " 属性获取结果: " + attrValue);
-                globalParams.put(variable, attrValue);
-                return;
+                attrValue = getCenterCoordinate(bounds);
+            } else {
+                attrValue = findEle(selector, pathValue).getAttribute(attr);
             }
-            String attrValue = findEle(selector, pathValue).getAttribute(attr);
             log.sendStepLog(StepType.INFO, "", attr + " 属性获取结果: " + attrValue);
             globalParams.put(variable, attrValue);
         } catch (Exception e) {
             handleContext.setE(e);
         }
+    }
+
+    private String getCenterCoordinate(String bounds) {
+        String[] parts = bounds.split("]\\[");
+        String[] xy = parts[0].substring(1).split(",");
+        String[] xy2 = parts[1].substring(0, parts[1].length() - 1).split(",");
+        return (Integer.parseInt(xy2[0]) + Integer.parseInt(xy[0])) / 2 + "," + (Integer.parseInt(xy2[1]) + Integer.parseInt(xy[1])) / 2;
     }
 
     public void logElementAttr(HandleContext handleContext, String des, String selector, String pathValue, String attr) {

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -673,6 +673,7 @@ public class AndroidStepHandler {
     }
 
     public void longPressPoint(HandleContext handleContext, String des, String xy, int time) {
+        xy = TextHandler.replaceTrans(xy, globalParams);
         double x = Double.parseDouble(xy.substring(0, xy.indexOf(",")));
         double y = Double.parseDouble(xy.substring(xy.indexOf(",") + 1));
         int[] point = computedPoint(x, y);
@@ -702,6 +703,7 @@ public class AndroidStepHandler {
     }
 
     public void tap(HandleContext handleContext, String des, String xy) {
+        xy = TextHandler.replaceTrans(xy, globalParams);
         double x = Double.parseDouble(xy.substring(0, xy.indexOf(",")));
         double y = Double.parseDouble(xy.substring(xy.indexOf(",") + 1));
         int[] point = computedPoint(x, y);
@@ -715,6 +717,9 @@ public class AndroidStepHandler {
     }
 
     public void swipePoint(HandleContext handleContext, String des1, String xy1, String des2, String xy2) {
+        // 让坐标系也支持变量替换
+        xy1 = TextHandler.replaceTrans(xy1, globalParams);
+        xy2 = TextHandler.replaceTrans(xy2, globalParams);
         double x1 = Double.parseDouble(xy1.substring(0, xy1.indexOf(",")));
         double y1 = Double.parseDouble(xy1.substring(xy1.indexOf(",") + 1));
         int[] point1 = computedPoint(x1, y1);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/AndroidStepHandler.java
@@ -1029,6 +1029,7 @@ public class AndroidStepHandler {
                 String[] xy2 = parts[1].substring(0, parts[1].length() - 1).split(",");
                 String attrValue = (Integer.parseInt(xy2[0]) + Integer.parseInt(xy[0])) / 2 + "," + (Integer.parseInt(xy2[1]) + Integer.parseInt(xy[1])) / 2;
                 log.sendStepLog(StepType.INFO, "", attr + " 属性获取结果: " + attrValue);
+                globalParams.put(variable, attrValue);
                 return;
             }
             String attrValue = findEle(selector, pathValue).getAttribute(attr);

--- a/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
+++ b/src/main/java/org/cloud/sonic/agent/tests/handlers/IOSStepHandler.java
@@ -507,6 +507,7 @@ public class IOSStepHandler {
 
     public void longPressPoint(HandleContext handleContext, String des, String xy, int time) {
         try {
+            xy = TextHandler.replaceTrans(xy, globalParams);
             double x = Double.parseDouble(xy.substring(0, xy.indexOf(",")));
             double y = Double.parseDouble(xy.substring(xy.indexOf(",") + 1));
             int[] point = computedPoint(x, y);
@@ -530,6 +531,7 @@ public class IOSStepHandler {
 
     public void tap(HandleContext handleContext, String des, String xy) {
         try {
+            xy = TextHandler.replaceTrans(xy, globalParams);
             double x = Double.parseDouble(xy.substring(0, xy.indexOf(",")));
             double y = Double.parseDouble(xy.substring(xy.indexOf(",") + 1));
             int[] point = computedPoint(x, y);
@@ -543,6 +545,8 @@ public class IOSStepHandler {
 
     public void swipePoint(HandleContext handleContext, String des1, String xy1, String des2, String xy2) {
         try {
+            xy1 = TextHandler.replaceTrans(xy1, globalParams);
+            xy2 = TextHandler.replaceTrans(xy2, globalParams);
             double x1 = Double.parseDouble(xy1.substring(0, xy1.indexOf(",")));
             double y1 = Double.parseDouble(xy1.substring(xy1.indexOf(",") + 1));
             int[] point1 = computedPoint(x1, y1);

--- a/src/test/java/org/cloud/sonic/agent/tests/handlers/TextHandlerTest.java
+++ b/src/test/java/org/cloud/sonic/agent/tests/handlers/TextHandlerTest.java
@@ -11,6 +11,9 @@ public class TextHandlerTest {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("hello", "world");
         jsonObject.put("hello2", "world2");
+        jsonObject.put("xy", "1,2");
+        jsonObject.put("x", "0.3");
+        jsonObject.put("y", "0.4");
         String s = TextHandler.replaceTrans("{{hello}}", jsonObject);
         Assert.assertEquals("world", s);
         s = TextHandler.replaceTrans("ss{{hello}}ss", jsonObject);
@@ -32,5 +35,9 @@ public class TextHandlerTest {
         Assert.assertTrue(Integer.parseInt(s) <= 6 && Integer.parseInt(s) >= 3);
         s = TextHandler.replaceTrans("{{random[h|2|3]}}", jsonObject);
         Assert.assertEquals(1, s.length());
+        s = TextHandler.replaceTrans("{{x}},{{y}}", jsonObject);
+        Assert.assertEquals("0.3,0.4", s);
+        s = TextHandler.replaceTrans("{{xy}}", jsonObject);
+        Assert.assertEquals("1,2", s);
     }
 }


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
![image](https://github.com/SonicCloudOrg/sonic-agent/assets/44832826/e1d655b4-22ac-4211-bda8-4a619a9c04b9)
例如上图一个城市选择器，使用控件定位可以获取到元素对象，但是滑动终点无法确定，考虑使用元素属性获取坐标后使用自定义脚本计算出滑动的起点、终点坐标，再使用坐标滑动方法操作，发现坐标系的控件参数化无效，因此增加这个参数化的代码


